### PR TITLE
Feat/7 Character Data Hub enhancements

### DIFF
--- a/SinusSynchronous/Services/CharaData/CharaDataGposeTogetherManager.cs
+++ b/SinusSynchronous/Services/CharaData/CharaDataGposeTogetherManager.cs
@@ -95,6 +95,7 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
     }
 
     public string? CurrentGPoseLobbyId { get; private set; }
+    public int? CurrentGPoseLobbyServerId { get; private set; }
     public string? LastGPoseLobbyId { get; private set; }
 
     public IEnumerable<GposeLobbyUserData> UsersInLobby => _usersInLobby.Values;
@@ -147,6 +148,7 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
             CurrentGPoseLobbyId = await _apiController.GposeLobbyCreate(serverIndex).ConfigureAwait(false);
             if (!string.IsNullOrEmpty(CurrentGPoseLobbyId))
             {
+                CurrentGPoseLobbyServerId = serverIndex;
                 _ = GposeWorldPositionBackgroundTask(serverIndex, _lobbyCts.Token);
                 _ = GposePoseDataBackgroundTask(serverIndex, _lobbyCts.Token);
             }
@@ -169,6 +171,7 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
                 }
 
                 CurrentGPoseLobbyId = joinLobbyId;
+                CurrentGPoseLobbyServerId = serverIndex;
                 _ = GposeWorldPositionBackgroundTask(serverIndex, _lobbyCts.Token);
                 _ = GposePoseDataBackgroundTask(serverIndex, _lobbyCts.Token);
             }
@@ -176,6 +179,7 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
             {
                 LeaveGPoseLobby(serverIndex);
                 LastGPoseLobbyId = string.Empty;
+                CurrentGPoseLobbyServerId = null;
             }
         });
     }
@@ -193,6 +197,7 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
                 }
 
                 ClearLobby(revertCharas: true);
+                CurrentGPoseLobbyServerId = null;
             }
         });
     }
@@ -364,6 +369,7 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
 
         while (!ct.IsCancellationRequested)
         {
+            //TODO maybe we can turn this timer into a setting, 5-20 seconds
             await Task.Delay(TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
             if (!_dalamudUtil.IsInGpose) continue;
             if (_usersInLobby.Count == 0) continue;
@@ -416,6 +422,7 @@ public class CharaDataGposeTogetherManager : DisposableMediatorSubscriberBase
     {
         while (!ct.IsCancellationRequested)
         {
+            //TODO maybe we can turn this timer into a setting, 5-20 seconds
             await Task.Delay(TimeSpan.FromSeconds(_dalamudUtil.IsInGpose ? 10 : 1), ct).ConfigureAwait(false);
 
             // if there are no players in lobby, don't do anything

--- a/SinusSynchronous/Services/CharaData/CharaDataManager.cs
+++ b/SinusSynchronous/Services/CharaData/CharaDataManager.cs
@@ -80,7 +80,9 @@ public sealed partial class CharaDataManager : DisposableMediatorSubscriberBase
         });
         sinusMediator.Subscribe<DisconnectedMessage>(this, (msg) =>
         {
-            // TODO based on server index
+            if(msg.ServerIndex != _serverConfig.CurrentServerIndex) 
+                return;
+
             _ownCharaData.Clear();
             _metaInfoCache.Clear();
             _sharedWithYouData.Clear();

--- a/SinusSynchronous/Services/CharaData/Models/CharaDataExtendedUpdateDto.cs
+++ b/SinusSynchronous/Services/CharaData/Models/CharaDataExtendedUpdateDto.cs
@@ -298,8 +298,10 @@ public sealed record CharaDataExtendedUpdateDto : CharaDataUpdateDto
         base.FileGamePaths = null;
         base.CustomizeData = null;
         base.ManipulationData = null;
-        AllowedUsers = null;
-        AllowedGroups = null;
+        AllowedUsers?.Clear();
+        UpdateAllowedUsers();
+        AllowedGroups?.Clear();
+        UpdateAllowedGroups();
         Poses = null;
         _poseList.Clear();
         _poseList.AddRange(_charaDataFullDto.PoseData.Select(k => new PoseEntry(k.Id)

--- a/SinusSynchronous/Services/CharaData/Models/CharaDataFullExtendedDto.cs
+++ b/SinusSynchronous/Services/CharaData/Models/CharaDataFullExtendedDto.cs
@@ -12,7 +12,7 @@ public sealed record CharaDataFullExtendedDto : CharaDataFullDto
         HasMissingFiles = MissingFiles.Any();
     }
 
-    public int ServverIndex { get; set; }
+    public int ServerIndex { get; set; }
     public string FullId { get; set; }
     public bool HasMissingFiles { get; init; }
     public IReadOnlyCollection<GamePathEntry> MissingFiles { get; init; }

--- a/SinusSynchronous/Services/CharaData/Models/CharaDataFullExtendedDto.cs
+++ b/SinusSynchronous/Services/CharaData/Models/CharaDataFullExtendedDto.cs
@@ -12,6 +12,7 @@ public sealed record CharaDataFullExtendedDto : CharaDataFullDto
         HasMissingFiles = MissingFiles.Any();
     }
 
+    public int ServverIndex { get; set; }
     public string FullId { get; set; }
     public bool HasMissingFiles { get; init; }
     public IReadOnlyCollection<GamePathEntry> MissingFiles { get; init; }

--- a/SinusSynchronous/Services/CharaData/Models/CharaDataFullExtendedDto.cs
+++ b/SinusSynchronous/Services/CharaData/Models/CharaDataFullExtendedDto.cs
@@ -12,7 +12,6 @@ public sealed record CharaDataFullExtendedDto : CharaDataFullDto
         HasMissingFiles = MissingFiles.Any();
     }
 
-    public int ServerIndex { get; set; }
     public string FullId { get; set; }
     public bool HasMissingFiles { get; init; }
     public IReadOnlyCollection<GamePathEntry> MissingFiles { get; init; }

--- a/SinusSynchronous/UI/CharaDataHubUi.GposeTogether.cs
+++ b/SinusSynchronous/UI/CharaDataHubUi.GposeTogether.cs
@@ -179,13 +179,13 @@ internal sealed partial class CharaDataHubUi
         if (!_uiSharedService.IsInGpose)
         {
             ImGuiHelpers.ScaledDummy(5);
-            UiSharedService.DrawGroupedCenteredColorText("Assigning users to characters is only available in GPose.", ImGuiColors.DalamudYellow, 320);
+            UiSharedService.DrawGroupedCenteredColorText("Assigning users to characters is only available in GPose.", ImGuiColors.DalamudYellow);
             ImGuiHelpers.ScaledDummy(5);
         }
         else if(string.IsNullOrEmpty(_charaDataGposeTogetherManager.CurrentGPoseLobbyId))
         {
             ImGuiHelpers.ScaledDummy(5);
-            UiSharedService.DrawGroupedCenteredColorText("Create or Join a Gpose Together lobby to assign characters.", ImGuiColors.DalamudYellow, 320);
+            UiSharedService.DrawGroupedCenteredColorText("Create or Join a Gpose Together lobby to assign characters.", ImGuiColors.DalamudYellow);
             ImGuiHelpers.ScaledDummy(5);
         }
         else

--- a/SinusSynchronous/UI/CharaDataHubUi.GposeTogether.cs
+++ b/SinusSynchronous/UI/CharaDataHubUi.GposeTogether.cs
@@ -97,6 +97,7 @@ internal sealed partial class CharaDataHubUi
         {
             ImGuiHelpers.ScaledDummy(5);
             UiSharedService.DrawGroupedCenteredColorText("Assigning users to characters is only available in GPose.", ImGuiColors.DalamudYellow, 320);
+            ImGuiHelpers.ScaledDummy(5);
         }
 
         using (ImRaii.Disabled(string.IsNullOrEmpty(_charaDataGposeTogetherManager.CurrentGPoseLobbyId)))

--- a/SinusSynchronous/UI/CharaDataHubUi.McdOnline.cs
+++ b/SinusSynchronous/UI/CharaDataHubUi.McdOnline.cs
@@ -28,7 +28,6 @@ internal sealed partial class CharaDataHubUi
         }
 
         var updateDto = _charaDataManager.GetUpdateDto(dataDto.Id);
-
         if (updateDto == null)
         {
             UiSharedService.DrawGroupedCenteredColorText("Something went awfully wrong and there's no update DTO. Try updating Character Data via the button above.", ImGuiColors.DalamudYellow);
@@ -563,7 +562,8 @@ internal sealed partial class CharaDataHubUi
 
     private void DrawMcdOnline()
     {
-        _uiSharedService.BigText("Sinus Character Data Online");
+        var serverName = _apiController.GetServerNameByIndex(_selectedServerIndex);
+        _uiSharedService.BigText($"{serverName} Character Data Online");
 
         DrawHelpFoldout("In this tab you can create, view and edit your own Sinus Character Data that is stored on the server." + Environment.NewLine + Environment.NewLine
             + "Sinus Character Data Online functions similar to the previous MCDF standard for exporting your character, except that you do not have to send a file to the other person but solely a code." + Environment.NewLine + Environment.NewLine
@@ -800,6 +800,11 @@ internal sealed partial class CharaDataHubUi
         {
             using (ImRaii.Disabled(updateDto.AccessType != AccessTypeDto.Individuals))
             {
+                float itemHeight = ImGui.GetTextLineHeightWithSpacing();
+                float padding = 5f;
+                int itemCount = Math.Max(Math.Max(updateDto.UserList.Count(), updateDto.GroupList.Count()), 1);
+                float listHeight = (itemCount * itemHeight) + padding;
+
                 using (ImRaii.PushId("user"))
                 {
                     using (ImRaii.Group())
@@ -821,14 +826,21 @@ internal sealed partial class CharaDataHubUi
                         _uiSharedService.DrawHelpText("Users added to this list will be able to access this character data regardless of your pause or pair state with them." + UiSharedService.TooltipSeparator
                             + "Note: Mistyped entries will be automatically removed on updating data to server.");
 
-                        using (var lb = ImRaii.ListBox("Allowed Individuals"))
+                        using (var lb = ImRaii.ListBox("Allowed Individuals", new Vector2(0, listHeight)))
                         {
-                            foreach (var user in updateDto.UserList)
+                            if (!updateDto.UserList.Any())
                             {
-                                var userString = string.IsNullOrEmpty(user.Alias) ? user.UID : $"{user.Alias} ({user.UID})";
-                                if (ImGui.Selectable(userString, string.Equals(user.UID, _selectedSpecificUserIndividual, StringComparison.Ordinal)))
+                                ImGui.TextUnformatted("No specific individuals added yet.");
+                            }
+                            else
+                            {
+                                foreach (var user in updateDto.UserList)
                                 {
-                                    _selectedSpecificUserIndividual = user.UID;
+                                    var userString = string.IsNullOrEmpty(user.Alias) ? user.UID : $"{user.Alias} ({user.UID})";
+                                    if (ImGui.Selectable(userString, string.Equals(user.UID, _selectedSpecificUserIndividual, StringComparison.Ordinal)))
+                                    {
+                                        _selectedSpecificUserIndividual = user.UID;
+                                    }
                                 }
                             }
                         }
@@ -890,14 +902,21 @@ internal sealed partial class CharaDataHubUi
                         _uiSharedService.DrawHelpText("Users in Syncshells added to this list will be able to access this character data regardless of your pause or pair state with them." + UiSharedService.TooltipSeparator
                             + "Note: Mistyped entries will be automatically removed on updating data to server.");
 
-                        using (var lb = ImRaii.ListBox("Allowed Syncshells"))
+                        using (var lb = ImRaii.ListBox("Allowed Syncshells", new Vector2(0, listHeight)))
                         {
-                            foreach (var group in updateDto.GroupList)
+                            if (!updateDto.GroupList.Any())
                             {
-                                var userString = string.IsNullOrEmpty(group.Alias) ? group.GID : $"{group.Alias} ({group.GID})";
-                                if (ImGui.Selectable(userString, string.Equals(group.GID, _selectedSpecificGroupIndividual, StringComparison.Ordinal)))
+                                ImGui.TextUnformatted("No specific Syncshells added yet.");
+                            }
+                            else
+                            {
+                                foreach (var group in updateDto.GroupList)
                                 {
-                                    _selectedSpecificGroupIndividual = group.GID;
+                                    var userString = string.IsNullOrEmpty(group.Alias) ? group.GID : $"{group.Alias} ({group.GID})";
+                                    if (ImGui.Selectable(userString, string.Equals(group.GID, _selectedSpecificGroupIndividual, StringComparison.Ordinal)))
+                                    {
+                                        _selectedSpecificGroupIndividual = group.GID;
+                                    }
                                 }
                             }
                         }

--- a/SinusSynchronous/UI/CharaDataHubUi.McdOnline.cs
+++ b/SinusSynchronous/UI/CharaDataHubUi.McdOnline.cs
@@ -144,6 +144,28 @@ internal sealed partial class CharaDataHubUi
     private void DrawEditCharaDataAccessAndSharing(CharaDataExtendedUpdateDto updateDto)
     {
         _uiSharedService.BigText("Access and Sharing");
+        //test
+
+        UiSharedService.ScaledNextItemWidth(200);
+        var dtoShareType = updateDto.ShareType;
+        if (ImGui.BeginCombo("Sharing", GetShareTypeString(dtoShareType)))
+        {
+            foreach (var shareType in Enum.GetValues(typeof(ShareTypeDto)).Cast<ShareTypeDto>())
+            {
+                if (ImGui.Selectable(GetShareTypeString(shareType), shareType == dtoShareType))
+                {
+                    updateDto.ShareType = shareType;
+                }
+            }
+
+            ImGui.EndCombo();
+        }
+        _uiSharedService.DrawHelpText("This regulates how you want to distribute this character data." + UiSharedService.TooltipSeparator
+            + "Code Only: People require to have the code to download this character data" + Environment.NewLine
+            + "Shared: People that are allowed through 'Access Restrictions' will have this character data entry displayed in 'Shared with You' (it can also be accessed through the code)" + UiSharedService.TooltipSeparator
+            + "Note: Shared with Access Restriction 'Everyone' is the same as shared with Access Restriction 'All Pairs', it will not show up for everyone but just your pairs.");
+
+        ImGuiHelpers.ScaledDummy(10f);
 
         UiSharedService.ScaledNextItemWidth(200);
         var dtoAccessType = updateDto.AccessType;
@@ -169,27 +191,6 @@ internal sealed partial class CharaDataHubUi
             + "Note: Directly specified Individuals or Syncshells in the 'Specific Individuals / Syncshells' list will be able to access your character data regardless of pause or pair state.");
 
         DrawSpecific(updateDto);
-
-        UiSharedService.ScaledNextItemWidth(200);
-        var dtoShareType = updateDto.ShareType;
-        if (ImGui.BeginCombo("Sharing", GetShareTypeString(dtoShareType)))
-        {
-            foreach (var shareType in Enum.GetValues(typeof(ShareTypeDto)).Cast<ShareTypeDto>())
-            {
-                if (ImGui.Selectable(GetShareTypeString(shareType), shareType == dtoShareType))
-                {
-                    updateDto.ShareType = shareType;
-                }
-            }
-
-            ImGui.EndCombo();
-        }
-        _uiSharedService.DrawHelpText("This regulates how you want to distribute this character data." + UiSharedService.TooltipSeparator
-            + "Code Only: People require to have the code to download this character data" + Environment.NewLine
-            + "Shared: People that are allowed through 'Access Restrictions' will have this character data entry displayed in 'Shared with You' (it can also be accessed through the code)" + UiSharedService.TooltipSeparator
-            + "Note: Shared with Access Restriction 'Everyone' is the same as shared with Access Restriction 'All Pairs', it will not show up for everyone but just your pairs.");
-
-        ImGuiHelpers.ScaledDummy(10f);
     }
 
     private void DrawEditCharaDataAppearance(CharaDataFullExtendedDto dataDto, CharaDataExtendedUpdateDto updateDto)
@@ -284,13 +285,14 @@ internal sealed partial class CharaDataHubUi
             ImGui.InputText("##CharaDataCode", ref code, 255, ImGuiInputTextFlags.ReadOnly);
         }
         ImGui.SameLine();
-        ImGui.TextUnformatted("Chara Data Code");
+        ImGui.TextUnformatted("Character Data Sharing Code");
         ImGui.SameLine();
         if (_uiSharedService.IconButton(FontAwesomeIcon.Copy))
         {
             ImGui.SetClipboardText(code);
         }
-        UiSharedService.AttachToolTip("Copy Code to Clipboard");
+        _uiSharedService.DrawHelpText("Copy Code to Clipboard" + UiSharedService.TooltipSeparator
+            + "Note: The sharing code can be used to let other users to import this character data.");
 
         string creationTime = dataDto.CreatedDate.ToLocalTime().ToString();
         string updateTime = dataDto.UpdatedDate.ToLocalTime().ToString();
@@ -816,7 +818,7 @@ internal sealed partial class CharaDataHubUi
                     _uiSharedService.DrawHelpText("Users added to this list will be able to access this character data regardless of your pause or pair state with them." + UiSharedService.TooltipSeparator
                         + "Note: Mistyped entries will be automatically removed on updating data to server.");
 
-                    using (var lb = ImRaii.ListBox("Allowed Individuals", new(200 * ImGuiHelpers.GlobalScale, 200 * ImGuiHelpers.GlobalScale)))
+                    using (var lb = ImRaii.ListBox("Allowed Individuals"))
                     {
                         foreach (var user in updateDto.UserList)
                         {
@@ -885,7 +887,7 @@ internal sealed partial class CharaDataHubUi
                     _uiSharedService.DrawHelpText("Users in Syncshells added to this list will be able to access this character data regardless of your pause or pair state with them." + UiSharedService.TooltipSeparator
                         + "Note: Mistyped entries will be automatically removed on updating data to server.");
 
-                    using (var lb = ImRaii.ListBox("Allowed Syncshells", new(200 * ImGuiHelpers.GlobalScale, 200 * ImGuiHelpers.GlobalScale)))
+                    using (var lb = ImRaii.ListBox("Allowed Syncshells"))
                     {
                         foreach (var group in updateDto.GroupList)
                         {
@@ -932,7 +934,7 @@ internal sealed partial class CharaDataHubUi
 
             ImGui.Separator();
             ImGuiHelpers.ScaledDummy(5);
-        });
+        }, drawOpen: true);
     }
 
     private void InputComboHybrid<T>(string inputId, string comboId, ref string value, IEnumerable<T> comboEntries,

--- a/SinusSynchronous/UI/CharaDataHubUi.McdOnline.cs
+++ b/SinusSynchronous/UI/CharaDataHubUi.McdOnline.cs
@@ -144,7 +144,6 @@ internal sealed partial class CharaDataHubUi
     private void DrawEditCharaDataAccessAndSharing(CharaDataExtendedUpdateDto updateDto)
     {
         _uiSharedService.BigText("Access and Sharing");
-        //test
 
         UiSharedService.ScaledNextItemWidth(200);
         var dtoShareType = updateDto.ShareType;
@@ -165,7 +164,7 @@ internal sealed partial class CharaDataHubUi
             + "Shared: People that are allowed through 'Access Restrictions' will have this character data entry displayed in 'Shared with You' (it can also be accessed through the code)" + UiSharedService.TooltipSeparator
             + "Note: Shared with Access Restriction 'Everyone' is the same as shared with Access Restriction 'All Pairs', it will not show up for everyone but just your pairs.");
 
-        ImGuiHelpers.ScaledDummy(10f);
+        ImGuiHelpers.ScaledDummy(3f);
 
         UiSharedService.ScaledNextItemWidth(200);
         var dtoAccessType = updateDto.AccessType;
@@ -189,6 +188,8 @@ internal sealed partial class CharaDataHubUi
             + "Note: To access your character data the person in question requires to have the code. Exceptions for 'Shared' data, see 'Sharing' below." + Environment.NewLine
             + "Note: For 'Direct' and 'All Pairs' the pause state plays a role. Paused people will not be able to access your character data." + Environment.NewLine
             + "Note: Directly specified Individuals or Syncshells in the 'Specific Individuals / Syncshells' list will be able to access your character data regardless of pause or pair state.");
+
+        ImGuiHelpers.ScaledDummy(5f);
 
         DrawSpecific(updateDto);
     }
@@ -797,144 +798,147 @@ internal sealed partial class CharaDataHubUi
     {
         UiSharedService.DrawTree("Access for Specific Individuals / Syncshells", () =>
         {
-            using (ImRaii.PushId("user"))
+            using (ImRaii.Disabled(updateDto.AccessType != AccessTypeDto.Individuals))
             {
-                using (ImRaii.Group())
+                using (ImRaii.PushId("user"))
                 {
-                    InputComboHybrid("##AliasToAdd", "##AliasToAddPicker", ref _specificIndividualAdd, _pairManager.PairsWithGroups.Keys,
-                        static pair => (pair.UserData.UID, pair.UserData.Alias, pair.UserData.AliasOrUID, pair.GetNote()));
-                    ImGui.SameLine();
-                    using (ImRaii.Disabled(string.IsNullOrEmpty(_specificIndividualAdd)
-                        || updateDto.UserList.Any(f => string.Equals(f.UID, _specificIndividualAdd, StringComparison.Ordinal) || string.Equals(f.Alias, _specificIndividualAdd, StringComparison.Ordinal))))
+                    using (ImRaii.Group())
                     {
-                        if (_uiSharedService.IconButton(FontAwesomeIcon.Plus))
+                        InputComboHybrid("##AliasToAdd", "##AliasToAddPicker", ref _specificIndividualAdd, _pairManager.PairsWithGroups.Keys,
+                            static pair => (pair.UserData.UID, pair.UserData.Alias, pair.UserData.AliasOrUID, pair.GetNote()));
+                        ImGui.SameLine();
+                        using (ImRaii.Disabled(string.IsNullOrEmpty(_specificIndividualAdd)
+                            || updateDto.UserList.Any(f => string.Equals(f.UID, _specificIndividualAdd, StringComparison.Ordinal) || string.Equals(f.Alias, _specificIndividualAdd, StringComparison.Ordinal))))
                         {
-                            updateDto.AddUserToList(_specificIndividualAdd);
-                            _specificIndividualAdd = string.Empty;
-                        }
-                    }
-                    ImGui.SameLine();
-                    ImGui.TextUnformatted("UID/Vanity UID to Add");
-                    _uiSharedService.DrawHelpText("Users added to this list will be able to access this character data regardless of your pause or pair state with them." + UiSharedService.TooltipSeparator
-                        + "Note: Mistyped entries will be automatically removed on updating data to server.");
-
-                    using (var lb = ImRaii.ListBox("Allowed Individuals"))
-                    {
-                        foreach (var user in updateDto.UserList)
-                        {
-                            var userString = string.IsNullOrEmpty(user.Alias) ? user.UID : $"{user.Alias} ({user.UID})";
-                            if (ImGui.Selectable(userString, string.Equals(user.UID, _selectedSpecificUserIndividual, StringComparison.Ordinal)))
+                            if (_uiSharedService.IconButton(FontAwesomeIcon.Plus))
                             {
-                                _selectedSpecificUserIndividual = user.UID;
+                                updateDto.AddUserToList(_specificIndividualAdd);
+                                _specificIndividualAdd = string.Empty;
                             }
                         }
-                    }
+                        ImGui.SameLine();
+                        ImGui.TextUnformatted("UID/Vanity UID to Add");
+                        _uiSharedService.DrawHelpText("Users added to this list will be able to access this character data regardless of your pause or pair state with them." + UiSharedService.TooltipSeparator
+                            + "Note: Mistyped entries will be automatically removed on updating data to server.");
 
-                    using (ImRaii.Disabled(string.IsNullOrEmpty(_selectedSpecificUserIndividual)))
-                    {
-                        if (_uiSharedService.IconTextButton(FontAwesomeIcon.Trash, "Remove selected User"))
+                        using (var lb = ImRaii.ListBox("Allowed Individuals"))
                         {
-                            updateDto.RemoveUserFromList(_selectedSpecificUserIndividual);
-                            _selectedSpecificUserIndividual = string.Empty;
-                        }
-                    }
-
-                    using (ImRaii.Disabled(!UiSharedService.CtrlPressed()))
-                    {
-                        if (_uiSharedService.IconTextButton(FontAwesomeIcon.ExclamationTriangle, "Apply current Allowed Individuals to all MCDO entries"))
-                        {
-                            foreach (var own in _charaDataManager.OwnCharaData.Values.Where(k => !string.Equals(k.Id, updateDto.Id, StringComparison.Ordinal)))
+                            foreach (var user in updateDto.UserList)
                             {
-                                var otherUpdateDto = _charaDataManager.GetUpdateDto(own.Id);
-                                if (otherUpdateDto == null) continue;
-                                foreach (var user in otherUpdateDto.UserList.Select(k => k.UID).Concat(otherUpdateDto.AllowedUsers ?? []).Distinct(StringComparer.Ordinal).ToList())
+                                var userString = string.IsNullOrEmpty(user.Alias) ? user.UID : $"{user.Alias} ({user.UID})";
+                                if (ImGui.Selectable(userString, string.Equals(user.UID, _selectedSpecificUserIndividual, StringComparison.Ordinal)))
                                 {
-                                    otherUpdateDto.RemoveUserFromList(user);
-                                }
-                                foreach (var user in updateDto.UserList.Select(k => k.UID).Concat(updateDto.AllowedUsers ?? []).Distinct(StringComparer.Ordinal).ToList())
-                                {
-                                    otherUpdateDto.AddUserToList(user);
+                                    _selectedSpecificUserIndividual = user.UID;
                                 }
                             }
                         }
+
+                        using (ImRaii.Disabled(string.IsNullOrEmpty(_selectedSpecificUserIndividual)))
+                        {
+                            if (_uiSharedService.IconTextButton(FontAwesomeIcon.Trash, "Remove selected User"))
+                            {
+                                updateDto.RemoveUserFromList(_selectedSpecificUserIndividual);
+                                _selectedSpecificUserIndividual = string.Empty;
+                            }
+                        }
+
+                        using (ImRaii.Disabled(!UiSharedService.CtrlPressed()))
+                        {
+                            if (_uiSharedService.IconTextButton(FontAwesomeIcon.ExclamationTriangle, "Apply current Allowed Individuals to all MCDO entries"))
+                            {
+                                foreach (var own in _charaDataManager.OwnCharaData.Values.Where(k => !string.Equals(k.Id, updateDto.Id, StringComparison.Ordinal)))
+                                {
+                                    var otherUpdateDto = _charaDataManager.GetUpdateDto(own.Id);
+                                    if (otherUpdateDto == null) continue;
+                                    foreach (var user in otherUpdateDto.UserList.Select(k => k.UID).Concat(otherUpdateDto.AllowedUsers ?? []).Distinct(StringComparer.Ordinal).ToList())
+                                    {
+                                        otherUpdateDto.RemoveUserFromList(user);
+                                    }
+                                    foreach (var user in updateDto.UserList.Select(k => k.UID).Concat(updateDto.AllowedUsers ?? []).Distinct(StringComparer.Ordinal).ToList())
+                                    {
+                                        otherUpdateDto.AddUserToList(user);
+                                    }
+                                }
+                            }
+                        }
+                        UiSharedService.AttachToolTip("This will apply the current list of allowed specific individuals to ALL of your MCDO entries." + UiSharedService.TooltipSeparator
+                            + "Hold CTRL to enable.");
                     }
-                    UiSharedService.AttachToolTip("This will apply the current list of allowed specific individuals to ALL of your MCDO entries." + UiSharedService.TooltipSeparator
-                        + "Hold CTRL to enable.");
                 }
-            }
-            ImGui.SameLine();
-            ImGuiHelpers.ScaledDummy(20);
-            ImGui.SameLine();
+                ImGui.SameLine();
+                ImGuiHelpers.ScaledDummy(20);
+                ImGui.SameLine();
 
-            using (ImRaii.PushId("group"))
-            {
-                using (ImRaii.Group())
+                using (ImRaii.PushId("group"))
                 {
-                    InputComboHybrid("##GroupAliasToAdd", "##GroupAliasToAddPicker", ref _specificGroupAdd, _pairManager.Groups.Keys,
-                        group => (group.GroupData.GID, group.GroupData.Alias, group.GroupData.AliasOrGID, _serverConfigurationManager.GetNoteForGid(_selectedServerIndex, group.GroupData.GID)));
-                    ImGui.SameLine();
-                    using (ImRaii.Disabled(string.IsNullOrEmpty(_specificGroupAdd)
-                        || updateDto.GroupList.Any(f => string.Equals(f.GID, _specificGroupAdd, StringComparison.Ordinal) || string.Equals(f.Alias, _specificGroupAdd, StringComparison.Ordinal))))
+                    using (ImRaii.Group())
                     {
-                        if (_uiSharedService.IconButton(FontAwesomeIcon.Plus))
+                        InputComboHybrid("##GroupAliasToAdd", "##GroupAliasToAddPicker", ref _specificGroupAdd, _pairManager.Groups.Keys,
+                            group => (group.GroupData.GID, group.GroupData.Alias, group.GroupData.AliasOrGID, _serverConfigurationManager.GetNoteForGid(_selectedServerIndex, group.GroupData.GID)));
+                        ImGui.SameLine();
+                        using (ImRaii.Disabled(string.IsNullOrEmpty(_specificGroupAdd)
+                            || updateDto.GroupList.Any(f => string.Equals(f.GID, _specificGroupAdd, StringComparison.Ordinal) || string.Equals(f.Alias, _specificGroupAdd, StringComparison.Ordinal))))
                         {
-                            updateDto.AddGroupToList(_specificGroupAdd);
-                            _specificGroupAdd = string.Empty;
-                        }
-                    }
-                    ImGui.SameLine();
-                    ImGui.TextUnformatted("GID/Vanity GID to Add");
-                    _uiSharedService.DrawHelpText("Users in Syncshells added to this list will be able to access this character data regardless of your pause or pair state with them." + UiSharedService.TooltipSeparator
-                        + "Note: Mistyped entries will be automatically removed on updating data to server.");
-
-                    using (var lb = ImRaii.ListBox("Allowed Syncshells"))
-                    {
-                        foreach (var group in updateDto.GroupList)
-                        {
-                            var userString = string.IsNullOrEmpty(group.Alias) ? group.GID : $"{group.Alias} ({group.GID})";
-                            if (ImGui.Selectable(userString, string.Equals(group.GID, _selectedSpecificGroupIndividual, StringComparison.Ordinal)))
+                            if (_uiSharedService.IconButton(FontAwesomeIcon.Plus))
                             {
-                                _selectedSpecificGroupIndividual = group.GID;
+                                updateDto.AddGroupToList(_specificGroupAdd);
+                                _specificGroupAdd = string.Empty;
                             }
                         }
-                    }
+                        ImGui.SameLine();
+                        ImGui.TextUnformatted("GID/Vanity GID to Add");
+                        _uiSharedService.DrawHelpText("Users in Syncshells added to this list will be able to access this character data regardless of your pause or pair state with them." + UiSharedService.TooltipSeparator
+                            + "Note: Mistyped entries will be automatically removed on updating data to server.");
 
-                    using (ImRaii.Disabled(string.IsNullOrEmpty(_selectedSpecificGroupIndividual)))
-                    {
-                        if (_uiSharedService.IconTextButton(FontAwesomeIcon.Trash, "Remove selected Syncshell"))
+                        using (var lb = ImRaii.ListBox("Allowed Syncshells"))
                         {
-                            updateDto.RemoveGroupFromList(_selectedSpecificGroupIndividual);
-                            _selectedSpecificGroupIndividual = string.Empty;
-                        }
-                    }
-
-                    using (ImRaii.Disabled(!UiSharedService.CtrlPressed()))
-                    {
-                        if (_uiSharedService.IconTextButton(FontAwesomeIcon.ExclamationTriangle, "Apply current Allowed Syncshells to all MCDO entries"))
-                        {
-                            foreach (var own in _charaDataManager.OwnCharaData.Values.Where(k => !string.Equals(k.Id, updateDto.Id, StringComparison.Ordinal)))
+                            foreach (var group in updateDto.GroupList)
                             {
-                                var otherUpdateDto = _charaDataManager.GetUpdateDto(own.Id);
-                                if (otherUpdateDto == null) continue;
-                                foreach (var group in otherUpdateDto.GroupList.Select(k => k.GID).Concat(otherUpdateDto.AllowedGroups ?? []).Distinct(StringComparer.Ordinal).ToList())
+                                var userString = string.IsNullOrEmpty(group.Alias) ? group.GID : $"{group.Alias} ({group.GID})";
+                                if (ImGui.Selectable(userString, string.Equals(group.GID, _selectedSpecificGroupIndividual, StringComparison.Ordinal)))
                                 {
-                                    otherUpdateDto.RemoveGroupFromList(group);
-                                }
-                                foreach (var group in updateDto.GroupList.Select(k => k.GID).Concat(updateDto.AllowedGroups ?? []).Distinct(StringComparer.Ordinal).ToList())
-                                {
-                                    otherUpdateDto.AddGroupToList(group);
+                                    _selectedSpecificGroupIndividual = group.GID;
                                 }
                             }
                         }
+
+                        using (ImRaii.Disabled(string.IsNullOrEmpty(_selectedSpecificGroupIndividual)))
+                        {
+                            if (_uiSharedService.IconTextButton(FontAwesomeIcon.Trash, "Remove selected Syncshell"))
+                            {
+                                updateDto.RemoveGroupFromList(_selectedSpecificGroupIndividual);
+                                _selectedSpecificGroupIndividual = string.Empty;
+                            }
+                        }
+
+                        using (ImRaii.Disabled(!UiSharedService.CtrlPressed()))
+                        {
+                            if (_uiSharedService.IconTextButton(FontAwesomeIcon.ExclamationTriangle, "Apply current Allowed Syncshells to all MCDO entries"))
+                            {
+                                foreach (var own in _charaDataManager.OwnCharaData.Values.Where(k => !string.Equals(k.Id, updateDto.Id, StringComparison.Ordinal)))
+                                {
+                                    var otherUpdateDto = _charaDataManager.GetUpdateDto(own.Id);
+                                    if (otherUpdateDto == null) continue;
+                                    foreach (var group in otherUpdateDto.GroupList.Select(k => k.GID).Concat(otherUpdateDto.AllowedGroups ?? []).Distinct(StringComparer.Ordinal).ToList())
+                                    {
+                                        otherUpdateDto.RemoveGroupFromList(group);
+                                    }
+                                    foreach (var group in updateDto.GroupList.Select(k => k.GID).Concat(updateDto.AllowedGroups ?? []).Distinct(StringComparer.Ordinal).ToList())
+                                    {
+                                        otherUpdateDto.AddGroupToList(group);
+                                    }
+                                }
+                            }
+                        }
+                        UiSharedService.AttachToolTip("This will apply the current list of allowed specific syncshells to ALL of your MCDO entries." + UiSharedService.TooltipSeparator
+                            + "Hold CTRL to enable.");
                     }
-                    UiSharedService.AttachToolTip("This will apply the current list of allowed specific syncshells to ALL of your MCDO entries." + UiSharedService.TooltipSeparator
-                        + "Hold CTRL to enable.");
                 }
-            }
 
-            ImGui.Separator();
-            ImGuiHelpers.ScaledDummy(5);
-        }, drawOpen: true);
+                ImGui.Separator();
+                ImGuiHelpers.ScaledDummy(5);
+            }
+        }, drawOpen: (updateDto.AccessType == AccessTypeDto.Individuals));
     }
 
     private void InputComboHybrid<T>(string inputId, string comboId, ref string value, IEnumerable<T> comboEntries,

--- a/SinusSynchronous/UI/CharaDataHubUi.NearbyPoses.cs
+++ b/SinusSynchronous/UI/CharaDataHubUi.NearbyPoses.cs
@@ -21,6 +21,11 @@ internal partial class CharaDataHubUi
                         + "You can apply Shared World Poses to yourself or spawn the associated character to pose with them." + Environment.NewLine + Environment.NewLine
                         + "You can adjust the filter and change further settings in the 'Settings & Filter' foldout.");
 
+        if (!_apiController.ConnectedServerIndexes.Any(p => p == _selectedServerIndex))
+        {
+            _selectedServerIndex = _apiController.ConnectedServerIndexes.FirstOrDefault();
+        }
+
         UiSharedService.DrawTree("Settings & Filters", () =>
         {
             string filterByUser = _charaDataNearbyManager.UserNoteFilter;

--- a/SinusSynchronous/UI/CharaDataHubUi.NearbyPoses.cs
+++ b/SinusSynchronous/UI/CharaDataHubUi.NearbyPoses.cs
@@ -9,9 +9,9 @@ namespace SinusSynchronous.UI;
 
 internal partial class CharaDataHubUi
 {
-    private void DrawNearbyPoses()
+    private void DrawWorldPosesNearby()
     {
-        _uiSharedService.BigText("Poses Nearby");
+        _uiSharedService.BigText("World Poses Nearby");
 
         DrawHelpFoldout("This tab will show you all Shared World Poses nearby you." + Environment.NewLine + Environment.NewLine
                         + "Shared World Poses are poses in character data that have world data attached to them and are set to shared. "
@@ -90,10 +90,9 @@ internal partial class CharaDataHubUi
 
         ImGuiHelpers.ScaledDummy(3f);
 
-        using var indent = ImRaii.PushIndent(5f);
         if (_charaDataNearbyManager.NearbyData.Count == 0)
         {
-            UiSharedService.DrawGroupedCenteredColorText("No Shared World Poses found nearby.", ImGuiColors.DalamudYellow);
+            UiSharedService.DrawGroupedCenteredColorText("No Shared World Poses found nearby.", ImGuiColors.DalamudYellow, 400);
         }
 
         bool wasAnythingHovered = false;

--- a/SinusSynchronous/UI/CharaDataHubUi.cs
+++ b/SinusSynchronous/UI/CharaDataHubUi.cs
@@ -17,6 +17,7 @@ using SinusSynchronous.SinusConfiguration.Models;
 using SinusSynchronous.UI.Components;
 using SinusSynchronous.Utils;
 using SinusSynchronous.WebAPI;
+using System.Numerics;
 
 namespace SinusSynchronous.UI;
 
@@ -106,7 +107,15 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
             _sharedWithYouOwnerFilter = msg.UserData.AliasOrUID;
             UpdateFilteredItems();
         });
-        _serverSelector = new ServerSelectorSmall(index => _selectedServerIndex = index);
+        SizeConstraints = new WindowSizeConstraints()
+        {
+            MinimumSize = new Vector2(600, 400),
+            MaximumSize = new Vector2(1200, 2000),
+        };
+        _serverSelector = new ServerSelectorSmall(index => {
+            _selectedServerIndex = index;
+            _ = _charaDataManager.GetAllData(_selectedServerIndex, _disposalCts.Token);
+        });
     }
 
     private bool _openDataApplicationShared = false;
@@ -183,7 +192,7 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
 
         var availableWidth = ImGui.GetWindowContentRegionMax().X;
         _serverSelector.Draw(_serverConfigurationManager.GetServerNames(), _apiController.ConnectedServerIndexes, availableWidth);
-        
+
         using var disabled = ImRaii.Disabled(_disableUI);
 
         DisableDisabled(() =>
@@ -211,66 +220,28 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
         });
 
         using var tabs = ImRaii.TabBar("TabsTopLevel");
-        bool smallUi = false;
 
         _isHandlingSelf = _charaDataManager.HandledCharaData.Any(c => c.IsSelf);
         if (_isHandlingSelf) _openMcdOnlineOnNextRun = false;
 
-        using (var gposeTogetherTabItem = ImRaii.TabItem("GPose Together"))
+        using (var gposeTabItem = ImRaii.TabItem("GPose"))
         {
-            if (gposeTogetherTabItem)
+            if (gposeTabItem)
             {
-                smallUi = true;
-
+                DrawGposeControls();
+                ImGui.Separator();
                 DrawGposeTogether();
             }
         }
 
-        using (var applicationTabItem = ImRaii.TabItem("Data Application", _openDataApplicationShared ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
+        using (var nearbyPosesTabItem = ImRaii.TabItem("World Poses"))
         {
-            if (applicationTabItem)
+            if (nearbyPosesTabItem)
             {
-                smallUi = true;
-                using var appTabs = ImRaii.TabBar("TabsApplicationLevel");
+                using var id = ImRaii.PushId("nearbyPoseControls");
+                _charaDataNearbyManager.ComputeNearbyData = true;
 
-                using (ImRaii.Disabled(!_uiSharedService.IsInGpose))
-                {
-                    using (var gposeTabItem = ImRaii.TabItem("GPose Actors"))
-                    {
-                        if (gposeTabItem)
-                        {
-                            using var id = ImRaii.PushId("gposeControls");
-                            DrawGposeControls();
-                        }
-                    }
-                }
-                if (!_uiSharedService.IsInGpose)
-                    UiSharedService.AttachToolTip("Only available in GPose");
-
-                using (var nearbyPosesTabItem = ImRaii.TabItem("Poses Nearby"))
-                {
-                    if (nearbyPosesTabItem)
-                    {
-                        using var id = ImRaii.PushId("nearbyPoseControls");
-                        _charaDataNearbyManager.ComputeNearbyData = true;
-
-                        DrawNearbyPoses();
-                    }
-                    else
-                    {
-                        _charaDataNearbyManager.ComputeNearbyData = false;
-                    }
-                }
-
-                using (var gposeTabItem = ImRaii.TabItem("Apply Data", _openDataApplicationShared ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
-                {
-                    if (gposeTabItem)
-                    {
-                        smallUi |= true;
-                        using var id = ImRaii.PushId("applyData");
-                        DrawDataApplication();
-                    }
-                }
+                DrawWorldPosesNearby();
             }
             else
             {
@@ -280,42 +251,40 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
 
         using (ImRaii.Disabled(_isHandlingSelf))
         {
-            ImGuiTabItemFlags flagsTopLevel = ImGuiTabItemFlags.None;
-            if (_openMcdOnlineOnNextRun)
-            {
-                flagsTopLevel = ImGuiTabItemFlags.SetSelected;
-                _openMcdOnlineOnNextRun = false;
-            }
-
-            using (var creationTabItem = ImRaii.TabItem("Data Creation", flagsTopLevel))
+            using (var creationTabItem = ImRaii.TabItem("Character Data Online", _openMcdOnlineOnNextRun ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
             {
                 if (creationTabItem)
                 {
                     using var creationTabs = ImRaii.TabBar("TabsCreationLevel");
 
-                    ImGuiTabItemFlags flags = ImGuiTabItemFlags.None;
-                    if (_openMcdOnlineOnNextRun)
-                    {
-                        flags = ImGuiTabItemFlags.SetSelected;
-                        _openMcdOnlineOnNextRun = false;
-                    }
-                    using (var mcdOnlineTabItem = ImRaii.TabItem("SCD Online", flags))
+                    using (var mcdOnlineTabItem = ImRaii.TabItem("Data Creation", _openMcdOnlineOnNextRun ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
                     {
                         if (mcdOnlineTabItem)
                         {
                             using var id = ImRaii.PushId("mcdOnline");
                             DrawMcdOnline();
+                            _openMcdOnlineOnNextRun = false;
                         }
                     }
-
-                    using (var mcdfTabItem = ImRaii.TabItem("MCDF Export"))
+                    using (var gposeTabItem = ImRaii.TabItem("Apply Data"))
                     {
-                        if (mcdfTabItem)
+                        if (gposeTabItem)
                         {
-                            using var id = ImRaii.PushId("mcdfExport");
-                            DrawMcdfExport();
+                            using var id = ImRaii.PushId("applyData");
+                            DrawDataApplication();
                         }
                     }
+                }
+            }
+            using (var creationTabItem = ImRaii.TabItem("MCDF"))
+            {
+                if (creationTabItem)
+                {
+                    DrawMcdfExport();
+
+                    ImGui.Separator();
+
+                    DrawMcdfImport();
                 }
             }
         }
@@ -332,9 +301,6 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
                 DrawSettings();
             }
         }
-
-
-        SetWindowSizeConstraints(smallUi);
     }
 
     private void DrawAddOrRemoveFavorite(CharaDataFullDto dto)
@@ -374,59 +340,76 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
     {
         _uiSharedService.BigText("GPose Actors");
         ImGuiHelpers.ScaledDummy(5);
-        using var indent = ImRaii.PushIndent(10f);
 
-        foreach (var actor in _dalamudUtilService.GetGposeCharactersFromObjectTable())
+        if (!_uiSharedService.IsInGpose)
         {
-            if (actor == null) continue;
-            using var actorId = ImRaii.PushId(actor.Name.TextValue);
-            UiSharedService.DrawGrouped(() =>
+            ImGuiHelpers.ScaledDummy(5);
+            UiSharedService.DrawGroupedCenteredColorText("Gpose actors are only available in GPose.", ImGuiColors.DalamudYellow);
+            ImGuiHelpers.ScaledDummy(5);
+        }
+
+        using (ImRaii.Disabled(!_uiSharedService.IsInGpose))
+        {
+            using var indent = ImRaii.PushIndent(10f);
+
+            var gposeTarget = _dalamudUtilService.GetGposeTargetGameObjectAsync().GetAwaiter().GetResult();
+
+            foreach (var actor in _dalamudUtilService.GetGposeCharactersFromObjectTable())
             {
-                if (_uiSharedService.IconButton(FontAwesomeIcon.Crosshairs))
-                {
-                    unsafe
-                    {
-                        _dalamudUtilService.GposeTarget = (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)actor.Address;
-                    }
-                }
-                ImGui.SameLine();
-                UiSharedService.AttachToolTip($"Target the GPose Character {CharaName(actor.Name.TextValue)}");
-                ImGui.AlignTextToFramePadding();
-                var pos = ImGui.GetCursorPosX();
-                using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.HealerGreen, actor.Address == (_dalamudUtilService.GetGposeTargetGameObjectAsync().GetAwaiter().GetResult()?.Address ?? nint.Zero)))
-                {
-                    ImGui.TextUnformatted(CharaName(actor.Name.TextValue));
-                }
-                ImGui.SameLine(250);
-                var handled = _charaDataManager.HandledCharaData.FirstOrDefault(c => string.Equals(c.Name, actor.Name.TextValue, StringComparison.Ordinal));
-                using (ImRaii.Disabled(handled == null))
-                {
-                    _uiSharedService.IconText(FontAwesomeIcon.InfoCircle);
-                    var id = string.IsNullOrEmpty(handled?.MetaInfo.Uploader.UID) ? handled?.MetaInfo.Id : handled.MetaInfo.FullId;
-                    UiSharedService.AttachToolTip($"Applied Data: {id ?? "No data applied"}");
+                if (actor == null) continue;
+                var actorName = string.IsNullOrEmpty(actor.Name.TextValue) ? $"Unknown_{actor.Address}" : actor.Name.TextValue;
 
-                    ImGui.SameLine();
-                    // maybe do this better, check with brio for handled charas or sth
-                    using (ImRaii.Disabled(!actor.Name.TextValue.StartsWith("Brio ", StringComparison.Ordinal)))
+                UiSharedService.DrawGrouped(() =>
+                {
+                    using var actorId = ImRaii.PushId($"{actor.Address}_{actorName}");
+
+                    if (_uiSharedService.IconButton(FontAwesomeIcon.Crosshairs))
                     {
-                        if (_uiSharedService.IconButton(FontAwesomeIcon.Trash))
+                        unsafe
                         {
-                            _charaDataManager.RemoveChara(actor.Name.TextValue);
+                            _dalamudUtilService.GposeTarget = (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)actor.Address;
                         }
-                        UiSharedService.AttachToolTip($"Remove character {CharaName(actor.Name.TextValue)}");
                     }
                     ImGui.SameLine();
-                    if (_uiSharedService.IconButton(FontAwesomeIcon.Undo))
-                    {
-                        _charaDataManager.RevertChara(handled);
-                    }
-                    UiSharedService.AttachToolTip($"Revert applied data from {CharaName(actor.Name.TextValue)}");
-                    ImGui.SetCursorPosX(pos);
-                    DrawPoseData(handled?.MetaInfo, actor.Name.TextValue, true);
-                }
-            });
+                    UiSharedService.AttachToolTip($"Target the GPose Character {actorName}");
+                    ImGui.AlignTextToFramePadding();
+                    var pos = ImGui.GetCursorPosX();
 
-            ImGuiHelpers.ScaledDummy(2);
+                    using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.HealerGreen, actor.Address == (gposeTarget?.Address ?? nint.Zero)))
+                    {
+                        ImGui.TextUnformatted(CharaName(actor.Name.TextValue));
+                    }
+                    ImGui.SameLine(250);
+                    var handled = _charaDataManager.HandledCharaData.FirstOrDefault(c => string.Equals(c.Name, actor.Name.TextValue, StringComparison.Ordinal));
+                    using (ImRaii.Disabled(handled == null))
+                    {
+                        _uiSharedService.IconText(FontAwesomeIcon.InfoCircle);
+                        var id = string.IsNullOrEmpty(handled?.MetaInfo.Uploader.UID) ? handled?.MetaInfo.Id : handled.MetaInfo.FullId;
+                        UiSharedService.AttachToolTip($"Applied Data: {id ?? "No data applied"}");
+
+                        ImGui.SameLine();
+                        // maybe do this better, check with brio for handled charas or sth
+                        using (ImRaii.Disabled(!actor.Name.TextValue.StartsWith("Brio ", StringComparison.Ordinal)))
+                        {
+                            if (_uiSharedService.IconButton(FontAwesomeIcon.Trash))
+                            {
+                                _charaDataManager.RemoveChara(actor.Name.TextValue);
+                            }
+                            UiSharedService.AttachToolTip($"Remove character {actorName}");
+                        }
+                        ImGui.SameLine();
+                        if (_uiSharedService.IconButton(FontAwesomeIcon.Undo))
+                        {
+                            _charaDataManager.RevertChara(handled);
+                        }
+                        UiSharedService.AttachToolTip($"Revert applied data from {actorName}");
+                        ImGui.SetCursorPosX(pos);
+                        DrawPoseData(handled?.MetaInfo, actor.Name.TextValue, true);
+                    }
+                });
+
+                ImGuiHelpers.ScaledDummy(2);
+            }
         }
     }
 
@@ -446,7 +429,7 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
         if (!_hasValidGposeTarget)
         {
             ImGuiHelpers.ScaledDummy(3);
-            UiSharedService.DrawGroupedCenteredColorText("Applying data is only available in GPose with a valid selected GPose target.", ImGuiColors.DalamudYellow, 350);
+            UiSharedService.DrawGroupedCenteredColorText("Applying data is only available in GPose with a valid selected GPose target.", ImGuiColors.DalamudYellow, 420);
         }
 
         ImGuiHelpers.ScaledDummy(10);
@@ -610,24 +593,25 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
             }
         }
 
-        using (var byCodeTabItem = ImRaii.TabItem("Code"))
+        using (var byCodeTabItem = ImRaii.TabItem("Sharing Code"))
         {
             using var id = ImRaii.PushId("byCodeTab");
             if (byCodeTabItem)
             {
                 using var child = ImRaii.Child("sharedWithYouByCode", new(0, 0), false, ImGuiWindowFlags.AlwaysAutoResize);
-                DrawHelpFoldout("You can apply character data you have a code for in this tab. Provide the code in it's given format \"OwnerUID:DataId\" into the field below and click on " +
-                                "\"Get Info from Code\". This will provide you basic information about the data behind the code. Afterwards select an actor in GPose and press on \"Download and apply to <actor>\"." + Environment.NewLine + Environment.NewLine
-                                + "Description: as set by the owner of the code to give you more or additional information of what this code may contain." + Environment.NewLine
-                                + "Last Update: the date and time the owner of the code has last updated the data." + Environment.NewLine
-                                + "Is Downloadable: whether or not the code is downloadable and applicable. If the code is not downloadable, contact the owner so they can attempt to fix it." + Environment.NewLine + Environment.NewLine
-                                + "To download a code the code requires correct access permissions to be set by the owner. If getting info from the code fails, contact the owner to make sure they set their Access Permissions for the code correctly.");
+                DrawHelpFoldout("You can apply character data you have a sharing code for in this tab. Provide the code in it's given format \"OwnerUID:DataId\" into the field below and click on " +
+                                "\"Get Info from Code\". This will provide you basic information about the data behind the code. " + Environment.NewLine
+                                + " Afterwards select an actor in GPose and press on \"Download and apply to <actor>\"." + Environment.NewLine + Environment.NewLine
+                                + "Description: as set by the owner of the sharing code to give you more or additional information of what this code may contain." + Environment.NewLine
+                                + "Last Update: the date and time the owner of the sharing code has last updated the data." + Environment.NewLine
+                                + "Is Downloadable: whether or not the sharing code is downloadable and applicable. If the code is not downloadable, contact the owner so they can attempt to fix it." + Environment.NewLine + Environment.NewLine
+                                + "To download the character data, the code requires correct access permissions to be set by the owner. If getting info from the sharing code fails, contact the owner to make sure they set their Access Permissions for the code correctly.");
 
                 ImGuiHelpers.ScaledDummy(5);
-                ImGui.InputTextWithHint("##importCode", "Enter Data Code", ref _importCode, 100);
+                ImGui.InputTextWithHint("##importCode", "Enter Character Data Sharing Code", ref _importCode, 100);
                 using (ImRaii.Disabled(string.IsNullOrEmpty(_importCode)))
                 {
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowCircleDown, "Get Info from Code"))
+                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowCircleDown, "Get Info from Sharing Code"))
                     {
                         _charaDataManager.DownloadMetaInfo(_selectedServerIndex, _importCode);
                     }
@@ -797,78 +781,6 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
                 }
             }
         }
-
-        using (var mcdfTabItem = ImRaii.TabItem("From MCDF"))
-        {
-            using var id = ImRaii.PushId("applyMcdfTab");
-            if (mcdfTabItem)
-            {
-                using var child = ImRaii.Child("applyMcdf", new(0, 0), false, ImGuiWindowFlags.AlwaysAutoResize);
-                DrawHelpFoldout("You can apply character data shared with you using a MCDF file in this tab." + Environment.NewLine + Environment.NewLine
-                                + "Load the MCDF first via the \"Load MCDF\" button which will give you the basic description that the owner has set during export." + Environment.NewLine
-                                + "You can then apply it to any handled GPose actor." + Environment.NewLine + Environment.NewLine
-                                + "MCDF to share with others can be generated using the \"MCDF Export\" tab at the top.");
-
-                ImGuiHelpers.ScaledDummy(5);
-
-                if (_charaDataManager.LoadedMcdfHeader == null || _charaDataManager.LoadedMcdfHeader.IsCompleted)
-                {
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.FolderOpen, "Load MCDF"))
-                    {
-                        _fileDialogManager.OpenFileDialog("Pick MCDF file", ".mcdf", (success, paths) =>
-                        {
-                            if (!success) return;
-                            if (paths.FirstOrDefault() is not string path) return;
-
-                            _configService.Current.LastSavedCharaDataLocation = Path.GetDirectoryName(path) ?? string.Empty;
-                            _configService.Save();
-
-                            _charaDataManager.LoadMcdf(path);
-                        }, 1, Directory.Exists(_configService.Current.LastSavedCharaDataLocation) ? _configService.Current.LastSavedCharaDataLocation : null);
-                    }
-                    UiSharedService.AttachToolTip("Load MCDF Metadata into memory");
-                    if ((_charaDataManager.LoadedMcdfHeader?.IsCompleted ?? false))
-                    {
-                        ImGui.TextUnformatted("Loaded file");
-                        ImGui.SameLine(200);
-                        UiSharedService.TextWrapped(_charaDataManager.LoadedMcdfHeader.Result.LoadedFile.FilePath);
-                        ImGui.Text("Description");
-                        ImGui.SameLine(200);
-                        UiSharedService.TextWrapped(_charaDataManager.LoadedMcdfHeader.Result.LoadedFile.CharaFileData.Description);
-
-                        ImGuiHelpers.ScaledDummy(5);
-
-                        using (ImRaii.Disabled(!_hasValidGposeTarget))
-                        {
-                            if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowRight, "Apply"))
-                            {
-                                _ = _charaDataManager.McdfApplyToGposeTarget();
-                            }
-                            UiSharedService.AttachToolTip($"Apply to {_gposeTarget}");
-                            ImGui.SameLine();
-                            using (ImRaii.Disabled(!_charaDataManager.BrioAvailable))
-                            {
-                                if (_uiSharedService.IconTextButton(FontAwesomeIcon.Plus, "Spawn Actor and Apply"))
-                                {
-                                    _charaDataManager.McdfSpawnApplyToGposeTarget();
-                                }
-                            }
-                        }
-                    }
-                    if ((_charaDataManager.LoadedMcdfHeader?.IsFaulted ?? false) || (_charaDataManager.McdfApplicationTask?.IsFaulted ?? false))
-                    {
-                        UiSharedService.ColorTextWrapped("Failure to read MCDF file. MCDF file is possibly corrupt. Re-export the MCDF file and try again.",
-                            ImGuiColors.DalamudRed);
-                        UiSharedService.ColorTextWrapped("Note: if this is your MCDF, try redrawing yourself, wait and re-export the file. " +
-                            "If you received it from someone else have them do the same.", ImGuiColors.DalamudYellow);
-                    }
-                }
-                else
-                {
-                    UiSharedService.ColorTextWrapped("Loading Character...", ImGuiColors.DalamudYellow);
-                }
-            }
-        }
     }
 
     private void DrawMcdfExport()
@@ -909,6 +821,76 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
                 " equipped and redraw your character before exporting.", ImGuiColors.DalamudYellow);
 
             ImGui.Unindent();
+        }
+    }
+
+    private void DrawMcdfImport()
+    {
+        _uiSharedService.BigText("Import");
+
+        using var child = ImRaii.Child("applyMcdf", new(0, 0), false, ImGuiWindowFlags.AlwaysAutoResize);
+        DrawHelpFoldout("You can apply character data shared with you using a MCDF file in this tab." + Environment.NewLine + Environment.NewLine
+                        + "Load the MCDF first via the \"Load MCDF\" button which will give you the basic description that the owner has set during export." + Environment.NewLine
+                        + "You can then apply it to any handled GPose actor." + Environment.NewLine + Environment.NewLine
+                        + "MCDF to share with others can be generated using the \"MCDF Export\" tab at the top.");
+
+        ImGuiHelpers.ScaledDummy(5);
+
+        if (_charaDataManager.LoadedMcdfHeader == null || _charaDataManager.LoadedMcdfHeader.IsCompleted)
+        {
+            if (_uiSharedService.IconTextButton(FontAwesomeIcon.FolderOpen, "Load MCDF"))
+            {
+                _fileDialogManager.OpenFileDialog("Pick MCDF file", ".mcdf", (success, paths) =>
+                {
+                    if (!success) return;
+                    if (paths.FirstOrDefault() is not string path) return;
+
+                    _configService.Current.LastSavedCharaDataLocation = Path.GetDirectoryName(path) ?? string.Empty;
+                    _configService.Save();
+
+                    _charaDataManager.LoadMcdf(path);
+                }, 1, Directory.Exists(_configService.Current.LastSavedCharaDataLocation) ? _configService.Current.LastSavedCharaDataLocation : null);
+            }
+            UiSharedService.AttachToolTip("Load MCDF Metadata into memory");
+            if ((_charaDataManager.LoadedMcdfHeader?.IsCompleted ?? false))
+            {
+                ImGui.TextUnformatted("Loaded file");
+                ImGui.SameLine(200);
+                UiSharedService.TextWrapped(_charaDataManager.LoadedMcdfHeader.Result.LoadedFile.FilePath);
+                ImGui.Text("Description");
+                ImGui.SameLine(200);
+                UiSharedService.TextWrapped(_charaDataManager.LoadedMcdfHeader.Result.LoadedFile.CharaFileData.Description);
+
+                ImGuiHelpers.ScaledDummy(5);
+
+                using (ImRaii.Disabled(!_hasValidGposeTarget))
+                {
+                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowRight, "Apply"))
+                    {
+                        _ = _charaDataManager.McdfApplyToGposeTarget();
+                    }
+                    UiSharedService.AttachToolTip($"Apply to {_gposeTarget}");
+                    ImGui.SameLine();
+                    using (ImRaii.Disabled(!_charaDataManager.BrioAvailable))
+                    {
+                        if (_uiSharedService.IconTextButton(FontAwesomeIcon.Plus, "Spawn Actor and Apply"))
+                        {
+                            _charaDataManager.McdfSpawnApplyToGposeTarget();
+                        }
+                    }
+                }
+            }
+            if ((_charaDataManager.LoadedMcdfHeader?.IsFaulted ?? false) || (_charaDataManager.McdfApplicationTask?.IsFaulted ?? false))
+            {
+                UiSharedService.ColorTextWrapped("Failure to read MCDF file. MCDF file is possibly corrupt. Re-export the MCDF file and try again.",
+                    ImGuiColors.DalamudRed);
+                UiSharedService.ColorTextWrapped("Note: if this is your MCDF, try redrawing yourself, wait and re-export the file. " +
+                    "If you received it from someone else have them do the same.", ImGuiColors.DalamudYellow);
+            }
+        }
+        else
+        {
+            UiSharedService.ColorTextWrapped("Loading Character...", ImGuiColors.DalamudYellow);
         }
     }
 
@@ -965,7 +947,7 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
             {
                 using (ImRaii.Disabled(_isHandlingSelf))
                 {
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Edit, "Open in SCD Online Editor"))
+                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Edit, "Open in Character Data Online Editor"))
                     {
                         SelectedDtoId = data.Id;
                         _openMcdOnlineOnNextRun = true;

--- a/SinusSynchronous/UI/CharaDataHubUi.cs
+++ b/SinusSynchronous/UI/CharaDataHubUi.cs
@@ -112,10 +112,11 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
             MinimumSize = new Vector2(600, 400),
             MaximumSize = new Vector2(1200, 2000),
         };
-        _serverSelector = new ServerSelectorSmall(index => {
+        _serverSelector = new ServerSelectorSmall(index =>
+        {
             _selectedServerIndex = index;
             _ = _charaDataManager.GetAllData(_selectedServerIndex, _disposalCts.Token);
-        });
+        }, _apiController.ConnectedServerIndexes.FirstOrDefault());
     }
 
     private bool _openDataApplicationShared = false;
@@ -224,36 +225,30 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
         _isHandlingSelf = _charaDataManager.HandledCharaData.Any(c => c.IsSelf);
         if (_isHandlingSelf) _openMcdOnlineOnNextRun = false;
 
-        using (var gposeTabItem = ImRaii.TabItem("GPose"))
+        _uiSharedService.CreateTabItem("GPose", () =>
         {
-            if (gposeTabItem)
-            {
+            using (var id = ImRaii.PushId("gposeControls"))
                 DrawGposeControls();
-                ImGui.Separator();
+
+            ImGui.Separator();
+
+            using (var id = ImRaii.PushId("gposTogetherControls"))
                 DrawGposeTogether();
-            }
-        }
+        });
 
-        using (var nearbyPosesTabItem = ImRaii.TabItem("World Poses"))
+        _uiSharedService.CreateTabItem("World Poses", () =>
         {
-            if (nearbyPosesTabItem)
-            {
-                using var id = ImRaii.PushId("nearbyPoseControls");
-                _charaDataNearbyManager.ComputeNearbyData = true;
+            using var id = ImRaii.PushId("nearbyPoseControls");
+            _charaDataNearbyManager.ComputeNearbyData = true;
 
-                DrawWorldPosesNearby();
-            }
-            else
-            {
-                _charaDataNearbyManager.ComputeNearbyData = false;
-            }
-        }
+            DrawWorldPosesNearby();
+        });
 
         using (ImRaii.Disabled(_isHandlingSelf))
         {
             using (var creationTabItem = ImRaii.TabItem("Character Data Online", _openMcdOnlineOnNextRun ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
             {
-                if (creationTabItem)
+                if (creationTabItem.Success)
                 {
                     using var creationTabs = ImRaii.TabBar("TabsCreationLevel");
 
@@ -278,13 +273,15 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
             }
             using (var creationTabItem = ImRaii.TabItem("MCDF"))
             {
-                if (creationTabItem)
+                if (creationTabItem.Success)
                 {
-                    DrawMcdfExport();
+                    using (var id = ImRaii.PushId("mcdfExport"))
+                        DrawMcdfExport();
 
                     ImGui.Separator();
 
-                    DrawMcdfImport();
+                    using (var id = ImRaii.PushId("mcdfImport"))
+                        DrawMcdfImport();
                 }
             }
         }
@@ -293,14 +290,7 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
             UiSharedService.AttachToolTip("Cannot use creation tools while having Character Data applied to self.");
         }
 
-        using (var settingsTabItem = ImRaii.TabItem("Settings"))
-        {
-            if (settingsTabItem)
-            {
-                using var id = ImRaii.PushId("settings");
-                DrawSettings();
-            }
-        }
+        _uiSharedService.CreateTabItem("Settings", DrawSettings);
     }
 
     private void DrawAddOrRemoveFavorite(CharaDataFullDto dto)
@@ -334,84 +324,7 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
             else _configService.Current.FavoriteCodes[id] = new();
             _configService.Save();
         }
-    }
-
-    private void DrawGposeControls()
-    {
-        _uiSharedService.BigText("GPose Actors");
-        ImGuiHelpers.ScaledDummy(5);
-
-        if (!_uiSharedService.IsInGpose)
-        {
-            ImGuiHelpers.ScaledDummy(5);
-            UiSharedService.DrawGroupedCenteredColorText("Gpose actors are only available in GPose.", ImGuiColors.DalamudYellow);
-            ImGuiHelpers.ScaledDummy(5);
-        }
-
-        using (ImRaii.Disabled(!_uiSharedService.IsInGpose))
-        {
-            using var indent = ImRaii.PushIndent(10f);
-
-            var gposeTarget = _dalamudUtilService.GetGposeTargetGameObjectAsync().GetAwaiter().GetResult();
-
-            foreach (var actor in _dalamudUtilService.GetGposeCharactersFromObjectTable())
-            {
-                if (actor == null) continue;
-                var actorName = string.IsNullOrEmpty(actor.Name.TextValue) ? $"Unknown_{actor.Address}" : actor.Name.TextValue;
-
-                UiSharedService.DrawGrouped(() =>
-                {
-                    using var actorId = ImRaii.PushId($"{actor.Address}_{actorName}");
-
-                    if (_uiSharedService.IconButton(FontAwesomeIcon.Crosshairs))
-                    {
-                        unsafe
-                        {
-                            _dalamudUtilService.GposeTarget = (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)actor.Address;
-                        }
-                    }
-                    ImGui.SameLine();
-                    UiSharedService.AttachToolTip($"Target the GPose Character {actorName}");
-                    ImGui.AlignTextToFramePadding();
-                    var pos = ImGui.GetCursorPosX();
-
-                    using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.HealerGreen, actor.Address == (gposeTarget?.Address ?? nint.Zero)))
-                    {
-                        ImGui.TextUnformatted(CharaName(actor.Name.TextValue));
-                    }
-                    ImGui.SameLine(250);
-                    var handled = _charaDataManager.HandledCharaData.FirstOrDefault(c => string.Equals(c.Name, actor.Name.TextValue, StringComparison.Ordinal));
-                    using (ImRaii.Disabled(handled == null))
-                    {
-                        _uiSharedService.IconText(FontAwesomeIcon.InfoCircle);
-                        var id = string.IsNullOrEmpty(handled?.MetaInfo.Uploader.UID) ? handled?.MetaInfo.Id : handled.MetaInfo.FullId;
-                        UiSharedService.AttachToolTip($"Applied Data: {id ?? "No data applied"}");
-
-                        ImGui.SameLine();
-                        // maybe do this better, check with brio for handled charas or sth
-                        using (ImRaii.Disabled(!actor.Name.TextValue.StartsWith("Brio ", StringComparison.Ordinal)))
-                        {
-                            if (_uiSharedService.IconButton(FontAwesomeIcon.Trash))
-                            {
-                                _charaDataManager.RemoveChara(actor.Name.TextValue);
-                            }
-                            UiSharedService.AttachToolTip($"Remove character {actorName}");
-                        }
-                        ImGui.SameLine();
-                        if (_uiSharedService.IconButton(FontAwesomeIcon.Undo))
-                        {
-                            _charaDataManager.RevertChara(handled);
-                        }
-                        UiSharedService.AttachToolTip($"Revert applied data from {actorName}");
-                        ImGui.SetCursorPosX(pos);
-                        DrawPoseData(handled?.MetaInfo, actor.Name.TextValue, true);
-                    }
-                });
-
-                ImGuiHelpers.ScaledDummy(2);
-            }
-        }
-    }
+    }    
 
     private void DrawDataApplication()
     {
@@ -594,10 +507,10 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
         }
 
         using (var byCodeTabItem = ImRaii.TabItem("Sharing Code"))
-        {
-            using var id = ImRaii.PushId("byCodeTab");
+        {   
             if (byCodeTabItem)
             {
+                using var id = ImRaii.PushId("byCodeTab");
                 using var child = ImRaii.Child("sharedWithYouByCode", new(0, 0), false, ImGuiWindowFlags.AlwaysAutoResize);
                 DrawHelpFoldout("You can apply character data you have a sharing code for in this tab. Provide the code in it's given format \"OwnerUID:DataId\" into the field below and click on " +
                                 "\"Get Info from Code\". This will provide you basic information about the data behind the code. " + Environment.NewLine
@@ -669,10 +582,10 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
         }
 
         using (var yourOwnTabItem = ImRaii.TabItem("Your Own"))
-        {
-            using var id = ImRaii.PushId("yourOwnTab");
+        {   
             if (yourOwnTabItem)
             {
+                using var id = ImRaii.PushId("yourOwnTab");
                 DrawHelpFoldout("You can apply character data you created yourself in this tab. If the list is not populated press on \"Download your Character Data\"." + Environment.NewLine + Environment.NewLine
                                  + "To create new and edit your existing character data use the \"SCD Online\" tab.");
 
@@ -709,9 +622,9 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
 
         using (var sharedWithYouTabItem = ImRaii.TabItem("Shared With You", _openDataApplicationShared ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
         {
-            using var id = ImRaii.PushId("sharedWithYouTab");
             if (sharedWithYouTabItem)
             {
+                using var id = ImRaii.PushId("sharedWithYouTab");
                 DrawHelpFoldout("You can apply character data shared with you implicitly in this tab. Shared Character Data are Character Data entries that have \"Sharing\" set to \"Shared\" and you have access through those by meeting the access restrictions, " +
                                 "i.e. you were specified by your UID to gain access or are paired with the other user according to the Access Restrictions setting." + Environment.NewLine + Environment.NewLine
                                 + "Filter if needed to find a specific entry, then just press on \"Apply to <actor>\" and it will download and apply the Character Data to the currently targeted GPose actor." + Environment.NewLine + Environment.NewLine

--- a/SinusSynchronous/UI/CharaDataHubUi.cs
+++ b/SinusSynchronous/UI/CharaDataHubUi.cs
@@ -225,13 +225,8 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
         _isHandlingSelf = _charaDataManager.HandledCharaData.Any(c => c.IsSelf);
         if (_isHandlingSelf) _openMcdOnlineOnNextRun = false;
 
-        _uiSharedService.CreateTabItem("GPose", () =>
+        _uiSharedService.CreateTabItem("GPose Together", () =>
         {
-            using (var id = ImRaii.PushId("gposeControls"))
-                DrawGposeControls();
-
-            ImGui.Separator();
-
             using (var id = ImRaii.PushId("gposTogetherControls"))
                 DrawGposeTogether();
         });
@@ -244,51 +239,72 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
             DrawWorldPosesNearby();
         });
 
-        using (ImRaii.Disabled(_isHandlingSelf))
-        {
-            using (var creationTabItem = ImRaii.TabItem("Character Data Online", _openMcdOnlineOnNextRun ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
-            {
-                if (creationTabItem.Success)
-                {
-                    using var creationTabs = ImRaii.TabBar("TabsCreationLevel");
 
-                    using (var mcdOnlineTabItem = ImRaii.TabItem("Data Creation", _openMcdOnlineOnNextRun ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
+        using (var creationTabItem = ImRaii.TabItem("Character Data Online", _openMcdOnlineOnNextRun ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
+        {
+            if (creationTabItem.Success)
+            {
+                using var creationTabs = ImRaii.TabBar("TabsCreationLevel");
+
+                using (var mcdOnlineTabItem = ImRaii.TabItem("Data Creation", _openMcdOnlineOnNextRun ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
+                {
+                    if (mcdOnlineTabItem)
                     {
-                        if (mcdOnlineTabItem)
+                        using (ImRaii.Disabled(_isHandlingSelf))
                         {
                             using var id = ImRaii.PushId("mcdOnline");
                             DrawMcdOnline();
                             _openMcdOnlineOnNextRun = false;
                         }
                     }
-                    using (var gposeTabItem = ImRaii.TabItem("Apply Data"))
-                    {
-                        if (gposeTabItem)
-                        {
-                            using var id = ImRaii.PushId("applyData");
-                            DrawDataApplication();
-                        }
-                    }
                 }
-            }
-            using (var creationTabItem = ImRaii.TabItem("MCDF"))
-            {
-                if (creationTabItem.Success)
+
+                _uiSharedService.CreateTabItem("Apply Data", () =>
                 {
-                    using (var id = ImRaii.PushId("mcdfExport"))
-                        DrawMcdfExport();
+                    using var id = ImRaii.PushId("applyMcdoData");
+                    DrawDataApplication();
+                });
 
-                    ImGui.Separator();
-
-                    using (var id = ImRaii.PushId("mcdfImport"))
-                        DrawMcdfImport();
+                if (_isHandlingSelf)
+                {
+                    ImGuiHelpers.ScaledDummy(5);
+                    UiSharedService.DrawGroupedCenteredColorText("Cannot use creation tools while having Character Data applied to self.", ImGuiColors.DalamudYellow);
+                    ImGuiHelpers.ScaledDummy(5);
                 }
             }
         }
-        if (_isHandlingSelf)
+
+        _uiSharedService.CreateTabItem("MCDF", () =>
         {
-            UiSharedService.AttachToolTip("Cannot use creation tools while having Character Data applied to self.");
-        }
+            if (_uiSharedService.IsInGpose)
+            {
+                using (var id = ImRaii.PushId("gposeMcdfControls"))
+                {   
+                    DrawGposeControls();
+                    ImGui.Separator();
+                }
+            }
+            if (_isHandlingSelf)
+            {
+                ImGuiHelpers.ScaledDummy(5);
+                UiSharedService.DrawGroupedCenteredColorText("Cannot use creation tools while having Character Data applied to self.", ImGuiColors.DalamudYellow);
+                ImGuiHelpers.ScaledDummy(5);
+            }
+
+            using (ImRaii.Disabled(_isHandlingSelf))
+            {
+                using (var id = ImRaii.PushId("mcdfExport"))
+                    DrawMcdfExport();
+            }
+
+            ImGui.Separator();
+
+            using (ImRaii.Disabled(_isHandlingSelf))
+            {
+                using (var id = ImRaii.PushId("mcdfImport"))
+                    DrawMcdfImport();
+            }
+        });
 
         _uiSharedService.CreateTabItem("Settings", DrawSettings);
     }
@@ -324,10 +340,19 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
             else _configService.Current.FavoriteCodes[id] = new();
             _configService.Save();
         }
-    }    
+    }
 
     private void DrawDataApplication()
     {
+        if (_uiSharedService.IsInGpose)
+        {
+            using (var id = ImRaii.PushId("gposeDataApplicationControls"))
+            {
+                DrawGposeControls();
+                ImGui.Separator();
+            }
+        }
+
         _uiSharedService.BigText("Apply Character Appearance");
 
         ImGuiHelpers.ScaledDummy(5);
@@ -341,356 +366,379 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
 
         if (!_hasValidGposeTarget)
         {
-            ImGuiHelpers.ScaledDummy(3);
-            UiSharedService.DrawGroupedCenteredColorText("Applying data is only available in GPose with a valid selected GPose target.", ImGuiColors.DalamudYellow, 420);
+            ImGuiHelpers.ScaledDummy(5);
+            UiSharedService.DrawGroupedCenteredColorText("Applying data is only available in GPose with a valid selected GPose target.", ImGuiColors.DalamudYellow);
+            ImGuiHelpers.ScaledDummy(5);
+        }
+
+        if (_isHandlingSelf)
+        {
+            ImGuiHelpers.ScaledDummy(5);
+            UiSharedService.DrawGroupedCenteredColorText("Cannot use creation tools while having Character Data applied to self.", ImGuiColors.DalamudYellow);
+            ImGuiHelpers.ScaledDummy(5);
         }
 
         ImGuiHelpers.ScaledDummy(10);
 
-        using var tabs = ImRaii.TabBar("Tabs");
-
-        using (var byFavoriteTabItem = ImRaii.TabItem("Favorites"))
+        using (ImRaii.Disabled(_isHandlingSelf))
         {
-            if (byFavoriteTabItem)
+            using (var tabs = ImRaii.TabBar("Tabs"))
             {
-                using var id = ImRaii.PushId("byFavorite");
+                if (!tabs.Success)
+                    return;
 
-                ImGuiHelpers.ScaledDummy(5);
-
-                var max = ImGui.GetWindowContentRegionMax();
-                UiSharedService.DrawTree("Filters", () =>
+                using (var byFavoriteTabItem = ImRaii.TabItem("Favorites"))
                 {
-                    var maxIndent = ImGui.GetWindowContentRegionMax();
-                    ImGui.SetNextItemWidth(maxIndent.X - ImGui.GetCursorPosX());
-                    ImGui.InputTextWithHint("##ownFilter", "Code/Owner Filter", ref _filterCodeNote, 100);
-                    ImGui.SetNextItemWidth(maxIndent.X - ImGui.GetCursorPosX());
-                    ImGui.InputTextWithHint("##descFilter", "Custom Description Filter", ref _filterDescription, 100);
-                    ImGui.Checkbox("Only show entries with pose data", ref _filterPoseOnly);
-                    ImGui.Checkbox("Only show entries with world data", ref _filterWorldOnly);
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Ban, "Reset Filter"))
+                    if (byFavoriteTabItem)
                     {
-                        _filterCodeNote = string.Empty;
-                        _filterDescription = string.Empty;
-                        _filterPoseOnly = false;
-                        _filterWorldOnly = false;
+                        using var id = ImRaii.PushId("byFavorite");
+
+                        ImGuiHelpers.ScaledDummy(5);
+
+                        var max = ImGui.GetWindowContentRegionMax();
+                        UiSharedService.DrawTree("Filters", () =>
+                        {
+                            var maxIndent = ImGui.GetWindowContentRegionMax();
+                            ImGui.SetNextItemWidth(maxIndent.X - ImGui.GetCursorPosX());
+                            ImGui.InputTextWithHint("##ownFilter", "Code/Owner Filter", ref _filterCodeNote, 100);
+                            ImGui.SetNextItemWidth(maxIndent.X - ImGui.GetCursorPosX());
+                            ImGui.InputTextWithHint("##descFilter", "Custom Description Filter", ref _filterDescription, 100);
+                            ImGui.Checkbox("Only show entries with pose data", ref _filterPoseOnly);
+                            ImGui.Checkbox("Only show entries with world data", ref _filterWorldOnly);
+                            if (_uiSharedService.IconTextButton(FontAwesomeIcon.Ban, "Reset Filter"))
+                            {
+                                _filterCodeNote = string.Empty;
+                                _filterDescription = string.Empty;
+                                _filterPoseOnly = false;
+                                _filterWorldOnly = false;
+                            }
+                        });
+
+                        ImGuiHelpers.ScaledDummy(5);
+                        ImGui.Separator();
+                        using var scrollableChild = ImRaii.Child("favorite");
+                        ImGuiHelpers.ScaledDummy(5);
+                        using var totalIndent = ImRaii.PushIndent(5f);
+                        var cursorPos = ImGui.GetCursorPos();
+                        max = ImGui.GetWindowContentRegionMax();
+                        foreach (var favorite in _filteredFavorites.OrderByDescending(k => k.Value.Favorite.LastDownloaded))
+                        {
+                            UiSharedService.DrawGrouped(() =>
+                            {
+                                using var tableid = ImRaii.PushId(favorite.Key);
+                                ImGui.AlignTextToFramePadding();
+                                DrawFavorite(favorite.Key);
+                                using var innerIndent = ImRaii.PushIndent(25f);
+                                ImGui.SameLine();
+                                var xPos = ImGui.GetCursorPosX();
+                                var maxPos = (max.X - cursorPos.X);
+
+                                bool metaInfoDownloaded = favorite.Value.DownloadedMetaInfo;
+                                var metaInfo = favorite.Value.MetaInfo;
+
+                                ImGui.AlignTextToFramePadding();
+                                using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudGrey, !metaInfoDownloaded))
+                                using (ImRaii.PushColor(ImGuiCol.Text, UiSharedService.GetBoolColor(metaInfo != null), metaInfoDownloaded))
+                                    ImGui.TextUnformatted(favorite.Key);
+
+                                var iconSize = _uiSharedService.GetIconSize(FontAwesomeIcon.Check);
+                                var refreshButtonSize = _uiSharedService.GetIconButtonSize(FontAwesomeIcon.ArrowsSpin);
+                                var applyButtonSize = _uiSharedService.GetIconButtonSize(FontAwesomeIcon.ArrowRight);
+                                var addButtonSize = _uiSharedService.GetIconButtonSize(FontAwesomeIcon.Plus);
+                                var offsetFromRight = maxPos - (iconSize.X + refreshButtonSize.X + applyButtonSize.X + addButtonSize.X + (ImGui.GetStyle().ItemSpacing.X * 3.5f));
+
+                                ImGui.SameLine();
+                                ImGui.SetCursorPosX(offsetFromRight);
+                                if (metaInfoDownloaded)
+                                {
+                                    _uiSharedService.BooleanToColoredIcon(metaInfo != null, false);
+                                    if (metaInfo != null)
+                                    {
+                                        UiSharedService.AttachToolTip("Metainfo present" + UiSharedService.TooltipSeparator
+                                            + $"Last Updated: {metaInfo!.UpdatedDate}" + Environment.NewLine
+                                            + $"Description: {metaInfo!.Description}" + Environment.NewLine
+                                            + $"Poses: {metaInfo!.PoseData.Count}");
+                                    }
+                                    else
+                                    {
+                                        UiSharedService.AttachToolTip("Metainfo could not be downloaded." + UiSharedService.TooltipSeparator
+                                            + "The data associated with the code is either not present on the server anymore or you have no access to it");
+                                    }
+                                }
+                                else
+                                {
+                                    _uiSharedService.IconText(FontAwesomeIcon.QuestionCircle, ImGuiColors.DalamudGrey);
+                                    UiSharedService.AttachToolTip("Unknown accessibility state. Click the button on the right to refresh.");
+                                }
+
+                                ImGui.SameLine();
+                                bool isInTimeout = _charaDataManager.IsInTimeout(favorite.Key);
+                                using (ImRaii.Disabled(isInTimeout))
+                                {
+                                    if (_uiSharedService.IconButton(FontAwesomeIcon.ArrowsSpin))
+                                    {
+                                        _charaDataManager.DownloadMetaInfo(_selectedServerIndex, favorite.Key, false);
+                                        UpdateFilteredItems();
+                                    }
+                                }
+                                UiSharedService.AttachToolTip(isInTimeout ? "Timeout for refreshing active, please wait before refreshing again."
+                                    : "Refresh data for this entry from the Server.");
+
+                                ImGui.SameLine();
+                                GposeMetaInfoAction((meta) =>
+                                {
+                                    if (_uiSharedService.IconButton(FontAwesomeIcon.ArrowRight))
+                                    {
+                                        _ = _charaDataManager.ApplyCharaDataToGposeTarget(_selectedServerIndex, metaInfo!);
+                                    }
+                                }, "Apply Character Data to GPose Target", metaInfo, _hasValidGposeTarget, false);
+                                ImGui.SameLine();
+                                GposeMetaInfoAction((meta) =>
+                                {
+                                    if (_uiSharedService.IconButton(FontAwesomeIcon.Plus))
+                                    {
+                                        _ = _charaDataManager.SpawnAndApplyData(_selectedServerIndex, meta!);
+                                    }
+                                }, "Spawn Actor with Brio and apply Character Data", metaInfo, _hasValidGposeTarget, true);
+
+                                string uidText = string.Empty;
+                                var uid = favorite.Key.Split(":")[0];
+                                if (metaInfo != null)
+                                {
+                                    uidText = metaInfo.Uploader.AliasOrUID;
+                                }
+                                else
+                                {
+                                    uidText = uid;
+                                }
+
+                                var note = _serverConfigurationManager.GetNoteForUid(_selectedServerIndex, uid);
+                                if (note != null)
+                                {
+                                    uidText = $"{note} ({uidText})";
+                                }
+                                ImGui.TextUnformatted(uidText);
+
+                                ImGui.TextUnformatted("Last Use: ");
+                                ImGui.SameLine();
+                                ImGui.TextUnformatted(favorite.Value.Favorite.LastDownloaded == DateTime.MaxValue ? "Never" : favorite.Value.Favorite.LastDownloaded.ToString());
+
+                                var desc = favorite.Value.Favorite.CustomDescription;
+                                ImGui.SetNextItemWidth(maxPos - xPos);
+                                if (ImGui.InputTextWithHint("##desc", "Custom Description for Favorite", ref desc, 100))
+                                {
+                                    favorite.Value.Favorite.CustomDescription = desc;
+                                    _configService.Save();
+                                }
+
+                                DrawPoseData(metaInfo, _gposeTarget, _hasValidGposeTarget);
+                            });
+
+                            ImGuiHelpers.ScaledDummy(5);
+                        }
+
+                        if (_configService.Current.FavoriteCodes.Count == 0)
+                        {
+                            UiSharedService.ColorTextWrapped("You have no favorites added. Add Favorites through the other tabs before you can use this tab.", ImGuiColors.DalamudYellow);
+                        }
                     }
-                });
+                }
 
-                ImGuiHelpers.ScaledDummy(5);
-                ImGui.Separator();
-                using var scrollableChild = ImRaii.Child("favorite");
-                ImGuiHelpers.ScaledDummy(5);
-                using var totalIndent = ImRaii.PushIndent(5f);
-                var cursorPos = ImGui.GetCursorPos();
-                max = ImGui.GetWindowContentRegionMax();
-                foreach (var favorite in _filteredFavorites.OrderByDescending(k => k.Value.Favorite.LastDownloaded))
+                using (var byCodeTabItem = ImRaii.TabItem("Sharing Code"))
                 {
-                    UiSharedService.DrawGrouped(() =>
+                    if (byCodeTabItem)
                     {
-                        using var tableid = ImRaii.PushId(favorite.Key);
-                        ImGui.AlignTextToFramePadding();
-                        DrawFavorite(favorite.Key);
-                        using var innerIndent = ImRaii.PushIndent(25f);
-                        ImGui.SameLine();
-                        var xPos = ImGui.GetCursorPosX();
-                        var maxPos = (max.X - cursorPos.X);
+                        using var id = ImRaii.PushId("byCodeTab");
+                        using var child = ImRaii.Child("sharedWithYouByCode", new(0, 0), false, ImGuiWindowFlags.AlwaysAutoResize);
+                        DrawHelpFoldout("You can apply character data you have a sharing code for in this tab. Provide the code in it's given format \"OwnerUID:DataId\" into the field below and click on " +
+                                        "\"Get Info from Code\". This will provide you basic information about the data behind the code. " + Environment.NewLine
+                                        + " Afterwards select an actor in GPose and press on \"Download and apply to <actor>\"." + Environment.NewLine + Environment.NewLine
+                                        + "Description: as set by the owner of the sharing code to give you more or additional information of what this code may contain." + Environment.NewLine
+                                        + "Last Update: the date and time the owner of the sharing code has last updated the data." + Environment.NewLine
+                                        + "Is Downloadable: whether or not the sharing code is downloadable and applicable. If the code is not downloadable, contact the owner so they can attempt to fix it." + Environment.NewLine + Environment.NewLine
+                                        + "To download the character data, the code requires correct access permissions to be set by the owner. If getting info from the sharing code fails, contact the owner to make sure they set their Access Permissions for the code correctly.");
 
-                        bool metaInfoDownloaded = favorite.Value.DownloadedMetaInfo;
-                        var metaInfo = favorite.Value.MetaInfo;
-
-                        ImGui.AlignTextToFramePadding();
-                        using (ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudGrey, !metaInfoDownloaded))
-                        using (ImRaii.PushColor(ImGuiCol.Text, UiSharedService.GetBoolColor(metaInfo != null), metaInfoDownloaded))
-                            ImGui.TextUnformatted(favorite.Key);
-
-                        var iconSize = _uiSharedService.GetIconSize(FontAwesomeIcon.Check);
-                        var refreshButtonSize = _uiSharedService.GetIconButtonSize(FontAwesomeIcon.ArrowsSpin);
-                        var applyButtonSize = _uiSharedService.GetIconButtonSize(FontAwesomeIcon.ArrowRight);
-                        var addButtonSize = _uiSharedService.GetIconButtonSize(FontAwesomeIcon.Plus);
-                        var offsetFromRight = maxPos - (iconSize.X + refreshButtonSize.X + applyButtonSize.X + addButtonSize.X + (ImGui.GetStyle().ItemSpacing.X * 3.5f));
-
-                        ImGui.SameLine();
-                        ImGui.SetCursorPosX(offsetFromRight);
-                        if (metaInfoDownloaded)
+                        ImGuiHelpers.ScaledDummy(5);
+                        ImGui.InputTextWithHint("##importCode", "Enter Character Data Sharing Code", ref _importCode, 100);
+                        using (ImRaii.Disabled(string.IsNullOrEmpty(_importCode)))
                         {
-                            _uiSharedService.BooleanToColoredIcon(metaInfo != null, false);
-                            if (metaInfo != null)
+                            if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowCircleDown, "Get Info from Sharing Code"))
                             {
-                                UiSharedService.AttachToolTip("Metainfo present" + UiSharedService.TooltipSeparator
-                                    + $"Last Updated: {metaInfo!.UpdatedDate}" + Environment.NewLine
-                                    + $"Description: {metaInfo!.Description}" + Environment.NewLine
-                                    + $"Poses: {metaInfo!.PoseData.Count}");
-                            }
-                            else
-                            {
-                                UiSharedService.AttachToolTip("Metainfo could not be downloaded." + UiSharedService.TooltipSeparator
-                                    + "The data associated with the code is either not present on the server anymore or you have no access to it");
+                                _charaDataManager.DownloadMetaInfo(_selectedServerIndex, _importCode);
                             }
                         }
-                        else
+                        GposeMetaInfoAction((meta) =>
                         {
-                            _uiSharedService.IconText(FontAwesomeIcon.QuestionCircle, ImGuiColors.DalamudGrey);
-                            UiSharedService.AttachToolTip("Unknown accessibility state. Click the button on the right to refresh.");
-                        }
-
-                        ImGui.SameLine();
-                        bool isInTimeout = _charaDataManager.IsInTimeout(favorite.Key);
-                        using (ImRaii.Disabled(isInTimeout))
-                        {
-                            if (_uiSharedService.IconButton(FontAwesomeIcon.ArrowsSpin))
+                            if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowRight, $"Download and Apply"))
                             {
-                                _charaDataManager.DownloadMetaInfo(_selectedServerIndex, favorite.Key, false);
-                                UpdateFilteredItems();
+                                _ = _charaDataManager.ApplyCharaDataToGposeTarget(_selectedServerIndex, meta!);
                             }
-                        }
-                        UiSharedService.AttachToolTip(isInTimeout ? "Timeout for refreshing active, please wait before refreshing again."
-                            : "Refresh data for this entry from the Server.");
-
+                        }, "Apply this Character Data to the current GPose actor", _charaDataManager.LastDownloadedMetaInfo, _hasValidGposeTarget, false);
                         ImGui.SameLine();
                         GposeMetaInfoAction((meta) =>
                         {
-                            if (_uiSharedService.IconButton(FontAwesomeIcon.ArrowRight))
-                            {
-                                _ = _charaDataManager.ApplyCharaDataToGposeTarget(_selectedServerIndex, metaInfo!);
-                            }
-                        }, "Apply Character Data to GPose Target", metaInfo, _hasValidGposeTarget, false);
-                        ImGui.SameLine();
-                        GposeMetaInfoAction((meta) =>
-                        {
-                            if (_uiSharedService.IconButton(FontAwesomeIcon.Plus))
+                            if (_uiSharedService.IconTextButton(FontAwesomeIcon.Plus, $"Download and Spawn"))
                             {
                                 _ = _charaDataManager.SpawnAndApplyData(_selectedServerIndex, meta!);
                             }
-                        }, "Spawn Actor with Brio and apply Character Data", metaInfo, _hasValidGposeTarget, true);
-
-                        string uidText = string.Empty;
-                        var uid = favorite.Key.Split(":")[0];
-                        if (metaInfo != null)
-                        {
-                            uidText = metaInfo.Uploader.AliasOrUID;
-                        }
-                        else
-                        {
-                            uidText = uid;
-                        }
-
-                        var note = _serverConfigurationManager.GetNoteForUid(_selectedServerIndex, uid);
-                        if (note != null)
-                        {
-                            uidText = $"{note} ({uidText})";
-                        }
-                        ImGui.TextUnformatted(uidText);
-
-                        ImGui.TextUnformatted("Last Use: ");
+                        }, "Spawn a new Brio actor and apply this Character Data", _charaDataManager.LastDownloadedMetaInfo, _hasValidGposeTarget, true);
                         ImGui.SameLine();
-                        ImGui.TextUnformatted(favorite.Value.Favorite.LastDownloaded == DateTime.MaxValue ? "Never" : favorite.Value.Favorite.LastDownloaded.ToString());
+                        ImGui.AlignTextToFramePadding();
+                        DrawAddOrRemoveFavorite(_charaDataManager.LastDownloadedMetaInfo);
 
-                        var desc = favorite.Value.Favorite.CustomDescription;
-                        ImGui.SetNextItemWidth(maxPos - xPos);
-                        if (ImGui.InputTextWithHint("##desc", "Custom Description for Favorite", ref desc, 100))
+                        ImGui.NewLine();
+                        if (!_charaDataManager.DownloadMetaInfoTask?.IsCompleted ?? false)
                         {
-                            favorite.Value.Favorite.CustomDescription = desc;
-                            _configService.Save();
+                            UiSharedService.ColorTextWrapped("Downloading meta info. Please wait.", ImGuiColors.DalamudYellow);
+                        }
+                        if ((_charaDataManager.DownloadMetaInfoTask?.IsCompleted ?? false) && !_charaDataManager.DownloadMetaInfoTask.Result.Success)
+                        {
+                            UiSharedService.ColorTextWrapped(_charaDataManager.DownloadMetaInfoTask.Result.Result, ImGuiColors.DalamudRed);
                         }
 
-                        DrawPoseData(metaInfo, _gposeTarget, _hasValidGposeTarget);
-                    });
-
-                    ImGuiHelpers.ScaledDummy(5);
-                }
-
-                if (_configService.Current.FavoriteCodes.Count == 0)
-                {
-                    UiSharedService.ColorTextWrapped("You have no favorites added. Add Favorites through the other tabs before you can use this tab.", ImGuiColors.DalamudYellow);
-                }
-            }
-        }
-
-        using (var byCodeTabItem = ImRaii.TabItem("Sharing Code"))
-        {   
-            if (byCodeTabItem)
-            {
-                using var id = ImRaii.PushId("byCodeTab");
-                using var child = ImRaii.Child("sharedWithYouByCode", new(0, 0), false, ImGuiWindowFlags.AlwaysAutoResize);
-                DrawHelpFoldout("You can apply character data you have a sharing code for in this tab. Provide the code in it's given format \"OwnerUID:DataId\" into the field below and click on " +
-                                "\"Get Info from Code\". This will provide you basic information about the data behind the code. " + Environment.NewLine
-                                + " Afterwards select an actor in GPose and press on \"Download and apply to <actor>\"." + Environment.NewLine + Environment.NewLine
-                                + "Description: as set by the owner of the sharing code to give you more or additional information of what this code may contain." + Environment.NewLine
-                                + "Last Update: the date and time the owner of the sharing code has last updated the data." + Environment.NewLine
-                                + "Is Downloadable: whether or not the sharing code is downloadable and applicable. If the code is not downloadable, contact the owner so they can attempt to fix it." + Environment.NewLine + Environment.NewLine
-                                + "To download the character data, the code requires correct access permissions to be set by the owner. If getting info from the sharing code fails, contact the owner to make sure they set their Access Permissions for the code correctly.");
-
-                ImGuiHelpers.ScaledDummy(5);
-                ImGui.InputTextWithHint("##importCode", "Enter Character Data Sharing Code", ref _importCode, 100);
-                using (ImRaii.Disabled(string.IsNullOrEmpty(_importCode)))
-                {
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowCircleDown, "Get Info from Sharing Code"))
-                    {
-                        _charaDataManager.DownloadMetaInfo(_selectedServerIndex, _importCode);
-                    }
-                }
-                GposeMetaInfoAction((meta) =>
-                {
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowRight, $"Download and Apply"))
-                    {
-                        _ = _charaDataManager.ApplyCharaDataToGposeTarget(_selectedServerIndex, meta!);
-                    }
-                }, "Apply this Character Data to the current GPose actor", _charaDataManager.LastDownloadedMetaInfo, _hasValidGposeTarget, false);
-                ImGui.SameLine();
-                GposeMetaInfoAction((meta) =>
-                {
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.Plus, $"Download and Spawn"))
-                    {
-                        _ = _charaDataManager.SpawnAndApplyData(_selectedServerIndex, meta!);
-                    }
-                }, "Spawn a new Brio actor and apply this Character Data", _charaDataManager.LastDownloadedMetaInfo, _hasValidGposeTarget, true);
-                ImGui.SameLine();
-                ImGui.AlignTextToFramePadding();
-                DrawAddOrRemoveFavorite(_charaDataManager.LastDownloadedMetaInfo);
-
-                ImGui.NewLine();
-                if (!_charaDataManager.DownloadMetaInfoTask?.IsCompleted ?? false)
-                {
-                    UiSharedService.ColorTextWrapped("Downloading meta info. Please wait.", ImGuiColors.DalamudYellow);
-                }
-                if ((_charaDataManager.DownloadMetaInfoTask?.IsCompleted ?? false) && !_charaDataManager.DownloadMetaInfoTask.Result.Success)
-                {
-                    UiSharedService.ColorTextWrapped(_charaDataManager.DownloadMetaInfoTask.Result.Result, ImGuiColors.DalamudRed);
-                }
-
-                using (ImRaii.Disabled(_charaDataManager.LastDownloadedMetaInfo == null))
-                {
-                    ImGuiHelpers.ScaledDummy(5);
-                    var metaInfo = _charaDataManager.LastDownloadedMetaInfo;
-                    ImGui.TextUnformatted("Description");
-                    ImGui.SameLine(150);
-                    UiSharedService.TextWrapped(string.IsNullOrEmpty(metaInfo?.Description) ? "-" : metaInfo.Description);
-                    ImGui.TextUnformatted("Last Update");
-                    ImGui.SameLine(150);
-                    ImGui.TextUnformatted(metaInfo?.UpdatedDate.ToLocalTime().ToString() ?? "-");
-                    ImGui.TextUnformatted("Is Downloadable");
-                    ImGui.SameLine(150);
-                    _uiSharedService.BooleanToColoredIcon(metaInfo?.CanBeDownloaded ?? false, inline: false);
-                    ImGui.TextUnformatted("Poses");
-                    ImGui.SameLine(150);
-                    if (metaInfo?.HasPoses ?? false)
-                        DrawPoseData(metaInfo, _gposeTarget, _hasValidGposeTarget);
-                    else
-                        _uiSharedService.BooleanToColoredIcon(false, false);
-                }
-            }
-        }
-
-        using (var yourOwnTabItem = ImRaii.TabItem("Your Own"))
-        {   
-            if (yourOwnTabItem)
-            {
-                using var id = ImRaii.PushId("yourOwnTab");
-                DrawHelpFoldout("You can apply character data you created yourself in this tab. If the list is not populated press on \"Download your Character Data\"." + Environment.NewLine + Environment.NewLine
-                                 + "To create new and edit your existing character data use the \"SCD Online\" tab.");
-
-                ImGuiHelpers.ScaledDummy(5);
-
-                using (ImRaii.Disabled(_charaDataManager.GetAllDataTask != null
-                    || (_charaDataManager.DataGetTimeoutTask != null && !_charaDataManager.DataGetTimeoutTask.IsCompleted)))
-                {
-                    if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowCircleDown, "Download your Character Data"))
-                    {
-                        _ = _charaDataManager.GetAllData(_selectedServerIndex, _disposalCts.Token);
-                    }
-                }
-                if (_charaDataManager.DataGetTimeoutTask != null && !_charaDataManager.DataGetTimeoutTask.IsCompleted)
-                {
-                    UiSharedService.AttachToolTip("You can only refresh all character data from server every minute. Please wait.");
-                }
-
-                ImGuiHelpers.ScaledDummy(5);
-                ImGui.Separator();
-
-                using var child = ImRaii.Child("ownDataChild", new(0, 0), false, ImGuiWindowFlags.AlwaysAutoResize);
-                using var indent = ImRaii.PushIndent(10f);
-                foreach (var data in _charaDataManager.OwnCharaData.Values)
-                {
-                    var hasMetaInfo = _charaDataManager.TryGetMetaInfo(data.FullId, out var metaInfo);
-                    if (!hasMetaInfo) continue;
-                    DrawMetaInfoData(_gposeTarget, _hasValidGposeTarget, metaInfo!, true);
-                }
-
-                ImGuiHelpers.ScaledDummy(5);
-            }
-        }
-
-        using (var sharedWithYouTabItem = ImRaii.TabItem("Shared With You", _openDataApplicationShared ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
-        {
-            if (sharedWithYouTabItem)
-            {
-                using var id = ImRaii.PushId("sharedWithYouTab");
-                DrawHelpFoldout("You can apply character data shared with you implicitly in this tab. Shared Character Data are Character Data entries that have \"Sharing\" set to \"Shared\" and you have access through those by meeting the access restrictions, " +
-                                "i.e. you were specified by your UID to gain access or are paired with the other user according to the Access Restrictions setting." + Environment.NewLine + Environment.NewLine
-                                + "Filter if needed to find a specific entry, then just press on \"Apply to <actor>\" and it will download and apply the Character Data to the currently targeted GPose actor." + Environment.NewLine + Environment.NewLine
-                                + "Note: Shared Data of Pairs you have paused will not be shown here.");
-
-                ImGuiHelpers.ScaledDummy(5);
-
-                DrawUpdateSharedDataButton();
-
-                int activeFilters = 0;
-                if (!string.IsNullOrEmpty(_sharedWithYouOwnerFilter)) activeFilters++;
-                if (!string.IsNullOrEmpty(_sharedWithYouDescriptionFilter)) activeFilters++;
-                if (_sharedWithYouDownloadableFilter) activeFilters++;
-                string filtersText = activeFilters == 0 ? "Filters" : $"Filters ({activeFilters} active)";
-                UiSharedService.DrawTree($"{filtersText}##filters", () =>
-                {
-                    var filterWidth = ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X;
-                    ImGui.SetNextItemWidth(filterWidth);
-                    if (ImGui.InputTextWithHint("##filter", "Filter by UID/Note", ref _sharedWithYouOwnerFilter, 30))
-                    {
-                        UpdateFilteredItems();
-                    }
-                    ImGui.SetNextItemWidth(filterWidth);
-                    if (ImGui.InputTextWithHint("##filterDesc", "Filter by Description", ref _sharedWithYouDescriptionFilter, 50))
-                    {
-                        UpdateFilteredItems();
-                    }
-                    if (ImGui.Checkbox("Only show downloadable", ref _sharedWithYouDownloadableFilter))
-                    {
-                        UpdateFilteredItems();
-                    }
-                });
-
-                if (_filteredDict == null && _charaDataManager.GetSharedWithYouTask == null)
-                {
-                    _filteredDict = _charaDataManager.SharedWithYouData
-                        .ToDictionary(k =>
+                        using (ImRaii.Disabled(_charaDataManager.LastDownloadedMetaInfo == null))
                         {
-                            var note = _serverConfigurationManager.GetNoteForUid(_selectedServerIndex, k.Key.UID);
-                            if (note == null) return k.Key.AliasOrUID;
-                            return $"{note} ({k.Key.AliasOrUID})";
-                        }, k => k.Value, StringComparer.OrdinalIgnoreCase)
-                        .Where(k => string.IsNullOrEmpty(_sharedWithYouOwnerFilter) || k.Key.Contains(_sharedWithYouOwnerFilter))
-                        .OrderBy(k => k.Key, StringComparer.OrdinalIgnoreCase).ToDictionary();
-                }
-
-                ImGuiHelpers.ScaledDummy(5);
-                ImGui.Separator();
-                using var child = ImRaii.Child("sharedWithYouChild", new(0, 0), false, ImGuiWindowFlags.AlwaysAutoResize);
-
-                ImGuiHelpers.ScaledDummy(5);
-                foreach (var entry in _filteredDict ?? [])
-                {
-                    bool isFilteredAndHasToBeOpened = entry.Key.Contains(_sharedWithYouOwnerFilter) && _openDataApplicationShared;
-                    if (isFilteredAndHasToBeOpened)
-                        ImGui.SetNextItemOpen(isFilteredAndHasToBeOpened);
-                    UiSharedService.DrawTree($"{entry.Key} - [{entry.Value.Count} Character Data Sets]##{entry.Key}", () =>
-                    {
-                        foreach (var data in entry.Value)
-                        {
-                            DrawMetaInfoData(_gposeTarget, _hasValidGposeTarget, data);
+                            ImGuiHelpers.ScaledDummy(5);
+                            var metaInfo = _charaDataManager.LastDownloadedMetaInfo;
+                            ImGui.TextUnformatted("Description");
+                            ImGui.SameLine(150);
+                            UiSharedService.TextWrapped(string.IsNullOrEmpty(metaInfo?.Description) ? "-" : metaInfo.Description);
+                            ImGui.TextUnformatted("Last Update");
+                            ImGui.SameLine(150);
+                            ImGui.TextUnformatted(metaInfo?.UpdatedDate.ToLocalTime().ToString() ?? "-");
+                            ImGui.TextUnformatted("Is Downloadable");
+                            ImGui.SameLine(150);
+                            _uiSharedService.BooleanToColoredIcon(metaInfo?.CanBeDownloaded ?? false, inline: false);
+                            ImGui.TextUnformatted("Poses");
+                            ImGui.SameLine(150);
+                            if (metaInfo?.HasPoses ?? false)
+                                DrawPoseData(metaInfo, _gposeTarget, _hasValidGposeTarget);
+                            else
+                                _uiSharedService.BooleanToColoredIcon(false, false);
                         }
+                    }
+                }
+
+                using (var yourOwnTabItem = ImRaii.TabItem("Your Own"))
+                {
+                    if (yourOwnTabItem)
+                    {
+                        using var id = ImRaii.PushId("yourOwnTab");
+                        DrawHelpFoldout("You can apply character data you created yourself in this tab. If the list is not populated press on \"Download your Character Data\"." + Environment.NewLine + Environment.NewLine
+                                         + "To create new and edit your existing character data use the \"SCD Online\" tab.");
+
                         ImGuiHelpers.ScaledDummy(5);
-                    });
-                    if (isFilteredAndHasToBeOpened)
-                        _openDataApplicationShared = false;
+
+                        using (ImRaii.Disabled(_charaDataManager.GetAllDataTask != null
+                            || (_charaDataManager.DataGetTimeoutTask != null && !_charaDataManager.DataGetTimeoutTask.IsCompleted)))
+                        {
+                            if (_uiSharedService.IconTextButton(FontAwesomeIcon.ArrowCircleDown, "Download your Character Data"))
+                            {
+                                _ = _charaDataManager.GetAllData(_selectedServerIndex, _disposalCts.Token);
+                            }
+                        }
+                        if (_charaDataManager.DataGetTimeoutTask != null && !_charaDataManager.DataGetTimeoutTask.IsCompleted)
+                        {
+                            UiSharedService.AttachToolTip("You can only refresh all character data from server every minute. Please wait.");
+                        }
+
+                        ImGuiHelpers.ScaledDummy(5);
+                        ImGui.Separator();
+
+                        using var child = ImRaii.Child("ownDataChild", new(0, 0), false, ImGuiWindowFlags.AlwaysAutoResize);
+                        using var indent = ImRaii.PushIndent(10f);
+                        foreach (var data in _charaDataManager.OwnCharaData.Values)
+                        {
+                            var hasMetaInfo = _charaDataManager.TryGetMetaInfo(data.FullId, out var metaInfo);
+                            if (!hasMetaInfo) continue;
+                            DrawMetaInfoData(_gposeTarget, _hasValidGposeTarget, metaInfo!, true);
+                        }
+
+                        ImGuiHelpers.ScaledDummy(5);
+                    }
+                }
+
+                using (var sharedWithYouTabItem = ImRaii.TabItem("Shared With You", _openDataApplicationShared ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
+                {
+                    if (sharedWithYouTabItem)
+                    {
+                        using var id = ImRaii.PushId("sharedWithYouTab");
+                        DrawHelpFoldout("You can apply character data shared with you implicitly in this tab. Shared Character Data are Character Data entries that have \"Sharing\" set to \"Shared\" and you have access through those by meeting the access restrictions, " +
+                                        "i.e. you were specified by your UID to gain access or are paired with the other user according to the Access Restrictions setting." + Environment.NewLine + Environment.NewLine
+                                        + "Filter if needed to find a specific entry, then just press on \"Apply to <actor>\" and it will download and apply the Character Data to the currently targeted GPose actor." + Environment.NewLine + Environment.NewLine
+                                        + "Note: Shared Data of Pairs you have paused will not be shown here.");
+
+                        ImGuiHelpers.ScaledDummy(5);
+
+                        DrawUpdateSharedDataButton();
+
+                        int activeFilters = 0;
+                        if (!string.IsNullOrEmpty(_sharedWithYouOwnerFilter)) activeFilters++;
+                        if (!string.IsNullOrEmpty(_sharedWithYouDescriptionFilter)) activeFilters++;
+                        if (_sharedWithYouDownloadableFilter) activeFilters++;
+                        string filtersText = activeFilters == 0 ? "Filters" : $"Filters ({activeFilters} active)";
+                        UiSharedService.DrawTree($"{filtersText}##filters", () =>
+                        {
+                            var filterWidth = ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X;
+                            ImGui.SetNextItemWidth(filterWidth);
+                            if (ImGui.InputTextWithHint("##filter", "Filter by UID/Note", ref _sharedWithYouOwnerFilter, 30))
+                            {
+                                UpdateFilteredItems();
+                            }
+                            ImGui.SetNextItemWidth(filterWidth);
+                            if (ImGui.InputTextWithHint("##filterDesc", "Filter by Description", ref _sharedWithYouDescriptionFilter, 50))
+                            {
+                                UpdateFilteredItems();
+                            }
+                            if (ImGui.Checkbox("Only show downloadable", ref _sharedWithYouDownloadableFilter))
+                            {
+                                UpdateFilteredItems();
+                            }
+                        });
+
+                        if (_filteredDict == null && _charaDataManager.GetSharedWithYouTask == null)
+                        {
+                            _filteredDict = _charaDataManager.SharedWithYouData
+                                .ToDictionary(k =>
+                                {
+                                    var note = _serverConfigurationManager.GetNoteForUid(_selectedServerIndex, k.Key.UID);
+                                    if (note == null) return k.Key.AliasOrUID;
+                                    return $"{note} ({k.Key.AliasOrUID})";
+                                }, k => k.Value, StringComparer.OrdinalIgnoreCase)
+                                .Where(k => string.IsNullOrEmpty(_sharedWithYouOwnerFilter) || k.Key.Contains(_sharedWithYouOwnerFilter))
+                                .OrderBy(k => k.Key, StringComparer.OrdinalIgnoreCase).ToDictionary();
+                        }
+
+                        ImGuiHelpers.ScaledDummy(5);
+                        if (_charaDataManager.GetSharedWithYouTask != null && !_charaDataManager.GetSharedWithYouTask.IsCompleted)
+                        {
+                            UiSharedService.ColorTextWrapped("Downloading shared character data. Please wait.", ImGuiColors.DalamudYellow);
+                        }
+
+                        if (_filteredDict?.Count > 0)
+                        {
+                            ImGui.Separator();
+                            using var child = ImRaii.Child("sharedWithYouChild", new(0, 0), false, ImGuiWindowFlags.AlwaysAutoResize);
+
+                            ImGuiHelpers.ScaledDummy(5);
+                            foreach (var entry in _filteredDict ?? [])
+                            {
+                                bool isFilteredAndHasToBeOpened = entry.Key.Contains(_sharedWithYouOwnerFilter) && _openDataApplicationShared;
+                                if (isFilteredAndHasToBeOpened)
+                                    ImGui.SetNextItemOpen(isFilteredAndHasToBeOpened);
+                                UiSharedService.DrawTree($"{entry.Key} - [{entry.Value.Count} Character Data Sets]##{entry.Key}", () =>
+                                {
+                                    foreach (var data in entry.Value)
+                                    {
+                                        DrawMetaInfoData(_gposeTarget, _hasValidGposeTarget, data);
+                                    }
+                                    ImGuiHelpers.ScaledDummy(5);
+                                });
+                                if (isFilteredAndHasToBeOpened)
+                                    _openDataApplicationShared = false;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -804,6 +852,11 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
         else
         {
             UiSharedService.ColorTextWrapped("Loading Character...", ImGuiColors.DalamudYellow);
+        }
+        if (!_hasValidGposeTarget)
+        {
+            ImGuiHelpers.ScaledDummy(3);
+            UiSharedService.DrawGroupedCenteredColorText("Applying data is only available in GPose with a valid selected GPose target.", ImGuiColors.DalamudYellow, 420);
         }
     }
 

--- a/SinusSynchronous/UI/Components/ServerSelectorSmall.cs
+++ b/SinusSynchronous/UI/Components/ServerSelectorSmall.cs
@@ -37,6 +37,10 @@ namespace SinusSynchronous.UI.Components
                     {
                         ChangeSelectedIndex(i);
                     }
+                    if (!isConnected)
+                    {
+                        UiSharedService.AttachToolTip($"You are currently not connected to {serverName} service.");
+                    }
                     if (isSelected)
                     {
                         ImGui.SetItemDefaultFocus();

--- a/SinusSynchronous/UI/CreateSyncshellUI.cs
+++ b/SinusSynchronous/UI/CreateSyncshellUI.cs
@@ -37,8 +37,8 @@ public class CreateSyncshellUI : WindowMediatorSubscriberBase
         _serverSelector = new ServerSelectorSmall(newIndex => _serverIndexForCreation = newIndex);
         SizeConstraints = new()
         {
-            MinimumSize = new(550, 330),
-            MaximumSize = new(550, 330)
+            MinimumSize = new(550, 350),
+            MaximumSize = new(550, 350)
         };
 
         Flags = ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse;

--- a/SinusSynchronous/UI/SettingsUi.cs
+++ b/SinusSynchronous/UI/SettingsUi.cs
@@ -2075,8 +2075,6 @@ public class SettingsUi : WindowMediatorSubscriberBase
         }
     }
 
-    
-
     private void UiSharedService_GposeEnd()
     {
         IsOpen = _wasOpen;

--- a/SinusSynchronous/UI/SettingsUi.cs
+++ b/SinusSynchronous/UI/SettingsUi.cs
@@ -109,7 +109,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         SizeConstraints = new WindowSizeConstraints()
         {
             MinimumSize = new Vector2(800, 400),
-            MaximumSize = new Vector2(800, 2000),
+            MaximumSize = new Vector2(1200, 2000),
         };
 
         Mediator.Subscribe<OpenSettingsUiMessage>(this, (_) => Toggle());
@@ -2075,7 +2075,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         }
     }
 
-    private void CreateTabItem(string name, Action drawAction)
+    private static void CreateTabItem(string name, Action drawAction)
     {
         using (var tabItem = ImRaii.TabItem(name))
         {

--- a/SinusSynchronous/UI/SettingsUi.cs
+++ b/SinusSynchronous/UI/SettingsUi.cs
@@ -2065,30 +2065,17 @@ public class SettingsUi : WindowMediatorSubscriberBase
         {
             if (tabBar.Success)
             {
-                CreateTabItem("General", DrawGeneral);
-                CreateTabItem("Performance", DrawPerformance);
-                CreateTabItem("Storage", DrawFileStorageSettings);
-                CreateTabItem("Transfers", DrawCurrentTransfers);
-                CreateTabItem("Service Settings", DrawServerConfiguration);
-                CreateTabItem("Debug", DrawDebug);
+                _uiShared.CreateTabItem("General", DrawGeneral);
+                _uiShared.CreateTabItem("Performance", DrawPerformance);
+                _uiShared.CreateTabItem("Storage", DrawFileStorageSettings);
+                _uiShared.CreateTabItem("Transfers", DrawCurrentTransfers);
+                _uiShared.CreateTabItem("Service Settings", DrawServerConfiguration);
+                _uiShared.CreateTabItem("Debug", DrawDebug);
             }
         }
     }
 
-    private static void CreateTabItem(string name, Action drawAction)
-    {
-        using (var tabItem = ImRaii.TabItem(name))
-        {
-            if (tabItem.Success)
-            {
-                using (var child = ImRaii.Child($"{name.Replace(" ", string.Empty)}Child", new Vector2(0, 0), false))
-                {
-                    if (child.Success) 
-                        drawAction?.Invoke();
-                }
-            }
-        }
-    }
+    
 
     private void UiSharedService_GposeEnd()
     {

--- a/SinusSynchronous/UI/UISharedService.cs
+++ b/SinusSynchronous/UI/UISharedService.cs
@@ -1144,6 +1144,21 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
             width <= 0 ? null : width);
     }
 
+    public void CreateTabItem(string name, Action drawAction)
+    {
+        using (var tabItem = ImRaii.TabItem(name))
+        {
+            if (tabItem.Success)
+            {
+                using (var child = ImRaii.Child($"{name.Replace(" ", string.Empty)}Child", new Vector2(0, 0), false))
+                {
+                    if (child.Success)
+                        drawAction?.Invoke();
+                }
+            }
+        }
+    }
+
     public IDalamudTextureWrap LoadImage(byte[] imageData)
     {
         return _textureProvider.CreateFromImageAsync(imageData).Result;

--- a/SinusSynchronous/WebAPI/SignalR/ApiController.cs
+++ b/SinusSynchronous/WebAPI/SignalR/ApiController.cs
@@ -128,7 +128,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
     public int[] ConnectedServerIndexes {
         get
         {
-            return [.._sinusClients.Keys];
+            return [.._sinusClients.Where(p=> p.Value._serverState == ServerState.Connected)?.Select(p=> p.Key) ?? []];
         }
     }
 

--- a/SinusSynchronous/WebAPI/SignalR/ApiController.cs
+++ b/SinusSynchronous/WebAPI/SignalR/ApiController.cs
@@ -109,6 +109,14 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase
         }
     }
 
+    public bool AnyServerConnecting
+    {
+        get
+        {
+            return _sinusClients.Any(client => client.Value._serverState == ServerState.Connecting);
+        }
+    }
+
     public bool AnyServerDisconnecting
     {
         get


### PR DESCRIPTION
Feature enhancements
✅ Reduced the amount of tabs.
✅ MCDF export and import in one tab.
✅ MCDO creation and apply in one tab.
✅ Gpose tab was renamed to Gpose Together.
✅ Poses Nearby tab was renamed to World Poses, and the feature is now called Shared World Poses.
✅ Gpose Actors appear on both tabs that can apply data to characters in gpose (mcdo or mcdf)
✅ Tabs no longer auto-adjust their width. The user can freely adjust it and most of the components will resize to fit.
✅ MCDO creation will expand the specific UID/GID group when creating a new data file.
✅ Sharing Codes are now properly named as such. They are the code to allow importing someone else's mcdo.
✅ Switching servers now properly load the saved mcdo on that service.
✅ The service select shared ui element will now explain why a service is greyed out, when you are disconnected from it.

Known bugs
❌ When connecting to a service while MCDO list is loaded, will append the entries from that service to the list. This bug already happened on old mare, and seems to be a race condition while loading the data from the server, and the reason it has a timer when reloading the data from the server.